### PR TITLE
refactor: simplify MCP server implementation and fix plugin templates

### DIFF
--- a/mcp_config/prompts.json
+++ b/mcp_config/prompts.json
@@ -43,5 +43,23 @@
       "Field name guessing",
       "Value fabrication"
     ]
+  },
+  "plugin_development": {
+    "package_requirement": "package plugin  // MANDATORY",
+    "function_requirement": "func Eval(...) (...)  // MANDATORY",
+    "import_restrictions": "Only Go standard library allowed",
+    "return_types": {
+      "checknode": "(bool, error)",
+      "data_processing": "(interface{}, bool, error) or (map[string]interface{}, error)"
+    },
+    "common_imports": [
+      "strings",
+      "regexp", 
+      "fmt",
+      "strconv",
+      "time",
+      "net",
+      "encoding/json"
+    ]
   }
 } 

--- a/src/api/mcp_handlers.go
+++ b/src/api/mcp_handlers.go
@@ -21,6 +21,7 @@ import (
 )
 
 var mcpServer *mcp.StandardMCPServer
+var mcpInitialized bool
 
 // Session management
 type MCPSession struct {
@@ -37,16 +38,72 @@ var (
 
 const (
 	MCPSessionHeader = "Mcp-Session-Id"
-	SessionTimeout   = 30 * time.Minute
+	SessionTimeout   = 48 * time.Hour
 )
 
 func init() {
-	// Initialize with simplified StandardMCPServer
+  // Initialize with simplified StandardMCPServer
 	mcpServer = mcp.NewStandardMCPServer()
+	mcpInitialized = false
 
 	// Start session cleanup goroutine
 	go sessionCleanup()
+
+	logger.Info("MCP server created, waiting for initialization")
 }
+
+// InitializeMCPServer initializes the MCP server with proper configuration
+func InitializeMCPServer(baseURL, token string) {
+	if mcpServer != nil && !mcpInitialized {
+		mcpServer.UpdateConfig(baseURL, token)
+
+		// Start migration of all tools
+		if err := mcpServer.StartMigration(); err != nil {
+			logger.Error("Failed to migrate MCP tools", "error", err)
+		} else {
+			mcpInitialized = true
+			logger.Info("MCP server fully initialized and migrated")
+		}
+	}
+}
+
+// checkLeaderMode checks if current node is leader, returns error response if not
+func checkLeaderMode(c echo.Context) error {
+	if !cluster.IsLeader {
+		return c.JSON(http.StatusForbidden, map[string]interface{}{
+			"error":           "MCP service is only available on leader nodes",
+			"message":         "This node is not the cluster leader. MCP operations are restricted to the leader node.",
+			"leader_required": true,
+		})
+	}
+	return nil
+}
+
+// GetMCPImplementationStatus returns current implementation status
+func GetMCPImplementationStatus() map[string]interface{} {
+	if mcpServer == nil {
+		return map[string]interface{}{
+			"initialized":      false,
+			"using_standard":   false,
+			"migration_status": "not_started",
+		}
+	}
+
+	tools := mcpServer.GetAPIMapper().GetAllAPITools()
+	return map[string]interface{}{
+		"initialized":    mcpInitialized,
+		"using_standard": true,
+		"library":        "mcp-go",
+		"tool_count":     len(tools),
+		"server_info":    "AgentSmith-HUB v0.1.2",
+		"migration_status": map[string]interface{}{
+			"completed": mcpInitialized,
+			"tools":     len(tools),
+		},
+	}
+}
+
+// --- Session Management ---
 
 // generateSessionID creates a cryptographically secure session ID
 func generateSessionID() string {
@@ -196,18 +253,43 @@ func handleMCP(c echo.Context) error {
 		return err
 	}
 
-	// Handle DELETE requests for session termination
-	if c.Request().Method == "DELETE" {
+	// Ensure MCP server is initialized
+	if !mcpInitialized {
+		// Try to initialize with current request context
+		scheme := "http"
+		if c.Request().TLS != nil {
+			scheme = "https"
+		}
+		baseURL := fmt.Sprintf("%s://%s", scheme, c.Request().Host)
+
+		// Use default token from config if available
+		token := c.Request().Header.Get("token")
+		if token != "" {
+			InitializeMCPServer(baseURL, token)
+		}
+
+		// If still not initialized, return error
+		if !mcpInitialized {
+			return c.JSON(http.StatusServiceUnavailable, map[string]interface{}{
+				"error": "MCP server not properly initialized",
+				"hint":  "Server is starting up, please try again in a moment",
+			})
+		}
+	}
+
+	// Handle different HTTP methods
+	switch c.Request().Method {
+	case "DELETE":
 		return handleMCPSessionDelete(c)
-	}
-
-	// Handle GET requests for SSE connections (like Cline)
-	if c.Request().Method == "GET" {
+	case "GET":
 		return handleMCPSSE(c)
+	case "POST":
+		return handleMCPPost(c)
+	default:
+		return c.JSON(http.StatusMethodNotAllowed, map[string]interface{}{
+			"error": "Method not allowed",
+		})
 	}
-
-	// Handle POST requests
-	return handleMCPPost(c)
 }
 
 // handleMCPSessionDelete handles session termination via DELETE request
@@ -290,46 +372,6 @@ func handleMCPPost(c echo.Context) error {
 		})
 	}
 
-	// Process request based on type
-	switch v := body.(type) {
-	case map[string]interface{}:
-		// Single JSON-RPC message
-		return handleSingleMessage(c, v, session)
-	case []interface{}:
-		// Batch JSON-RPC messages
-		return handleBatchMessages(c, v, session)
-	default:
-		return c.JSON(http.StatusBadRequest, map[string]string{
-			"error": "Invalid request format",
-		})
-	}
-}
-
-// handleMCPJSONRPC handles a JSON-RPC request using the StandardMCPServer
-func handleMCPJSONRPC(requestData []byte) ([]byte, error) {
-	// Use the StandardMCPServer to handle the request
-	return mcpServer.HandleJSONRPCRequest(requestData)
-}
-
-// handleSingleMessage processes a single JSON-RPC message
-func handleSingleMessage(c echo.Context, messageData map[string]interface{}, session *MCPSession) error {
-	// Convert to MCPMessage
-	messageBytes, _ := json.Marshal(messageData)
-	var message common.MCPMessage
-	if err := json.Unmarshal(messageBytes, &message); err != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{
-			"error": "Invalid JSON-RPC message format",
-		})
-	}
-
-	// Validate JSON-RPC format
-	if message.JSONRpc != "2.0" {
-		logger.Error("Invalid JSON-RPC version", "version", message.JSONRpc)
-		return c.JSON(http.StatusBadRequest, map[string]string{
-			"error": "Invalid JSON-RPC version, expected 2.0",
-		})
-	}
-
 	// Update MCP server configuration
 	scheme := "http"
 	if c.Request().TLS != nil {
@@ -338,14 +380,45 @@ func handleSingleMessage(c echo.Context, messageData map[string]interface{}, ses
 	baseURL := fmt.Sprintf("%s://%s", scheme, c.Request().Host)
 	mcpServer.UpdateConfig(baseURL, session.Token)
 
-	// Handle the MCP message using StandardMCPServer
-	responseBytes, err := handleMCPJSONRPC(messageBytes)
+	// Process request based on type
+	switch v := body.(type) {
+	case map[string]interface{}:
+		// Single JSON-RPC message
+		return handleSingleMCPMessage(c, v)
+	case []interface{}:
+		// Batch JSON-RPC messages
+		return handleBatchMCPMessages(c, v)
+	default:
+		return c.JSON(http.StatusBadRequest, map[string]string{
+			"error": "Invalid request format",
+		})
+	}
+}
+
+// handleSingleMCPMessage processes a single JSON-RPC message using StandardMCPServer
+func handleSingleMCPMessage(c echo.Context, messageData map[string]interface{}) error {
+	// Convert to bytes for StandardMCPServer
+	messageBytes, err := json.Marshal(messageData)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{
+			"error": "Failed to marshal message",
+		})
+	}
+
+	// Use StandardMCPServer to handle the request
+	responseBytes, err := mcpServer.HandleJSONRPCRequest(messageBytes)
 	if err != nil {
 		logger.Error("MCP server error", "error", err)
-		// Return error response in JSON-RPC format
+
+		// Create error response
+		var messageID interface{}
+		if id, ok := messageData["id"]; ok {
+			messageID = id
+		}
+
 		errorResponse := &common.MCPMessage{
 			JSONRpc: "2.0",
-			ID:      message.ID,
+			ID:      messageID,
 			Error: &common.MCPError{
 				Code:    -32603,
 				Message: "Internal error",
@@ -355,7 +428,7 @@ func handleSingleMessage(c echo.Context, messageData map[string]interface{}, ses
 		return c.JSON(http.StatusOK, errorResponse)
 	}
 
-	// Parse response and return
+	// Parse and return response
 	var response interface{}
 	if err := json.Unmarshal(responseBytes, &response); err != nil {
 		logger.Error("Failed to parse MCP response", "error", err)
@@ -364,21 +437,12 @@ func handleSingleMessage(c echo.Context, messageData map[string]interface{}, ses
 		})
 	}
 
-	// For now, return JSON response (could be enhanced to support streaming)
 	return c.JSON(http.StatusOK, response)
 }
 
-// handleBatchMessages processes batch JSON-RPC messages
-func handleBatchMessages(c echo.Context, messagesData []interface{}, session *MCPSession) error {
-	responses := make([]*common.MCPMessage, 0, len(messagesData))
-
-	// Update MCP server configuration
-	scheme := "http"
-	if c.Request().TLS != nil {
-		scheme = "https"
-	}
-	baseURL := fmt.Sprintf("%s://%s", scheme, c.Request().Host)
-	mcpServer.UpdateConfig(baseURL, session.Token)
+// handleBatchMCPMessages processes batch JSON-RPC messages
+func handleBatchMCPMessages(c echo.Context, messagesData []interface{}) error {
+	responses := make([]interface{}, 0, len(messagesData))
 
 	for _, messageData := range messagesData {
 		messageMap, ok := messageData.(map[string]interface{})
@@ -395,62 +459,29 @@ func handleBatchMessages(c echo.Context, messagesData []interface{}, session *MC
 			continue
 		}
 
-		// Convert to MCPMessage
-		messageBytes, _ := json.Marshal(messageMap)
-		var message common.MCPMessage
-		if err := json.Unmarshal(messageBytes, &message); err != nil {
+		// Convert to bytes for StandardMCPServer
+		messageBytes, err := json.Marshal(messageMap)
+		if err != nil {
 			errorResponse := &common.MCPMessage{
 				JSONRpc: "2.0",
 				ID:      messageMap["id"],
 				Error: &common.MCPError{
 					Code:    -32600,
 					Message: "Invalid Request",
-					Data:    "Invalid JSON-RPC message format",
+					Data:    "Failed to marshal message",
 				},
 			}
 			responses = append(responses, errorResponse)
 			continue
 		}
 
-		// Validate JSON-RPC format
-		if message.JSONRpc != "2.0" {
-			logger.Error("Invalid JSON-RPC version in batch", "version", message.JSONRpc)
-			errorResponse := &common.MCPMessage{
-				JSONRpc: "2.0",
-				ID:      message.ID,
-				Error: &common.MCPError{
-					Code:    -32600,
-					Message: "Invalid Request",
-					Data:    "Invalid JSON-RPC version, expected 2.0",
-				},
-			}
-			responses = append(responses, errorResponse)
-			continue
-		}
-
-		// Handle each message using StandardMCPServer
-		messageBytes, err := json.Marshal(message)
-		if err != nil {
-			logger.Error("Failed to marshal message in batch", "error", err)
-			errorResponse := &common.MCPMessage{
-				JSONRpc: "2.0",
-				ID:      message.ID,
-				Error: &common.MCPError{
-					Code:    -32603,
-					Message: "Internal error",
-					Data:    err.Error(),
-				},
-			}
-			responses = append(responses, errorResponse)
-			continue
-		}
-
-		responseBytes, err := handleMCPJSONRPC(messageBytes)
+		// Handle message using StandardMCPServer
+		responseBytes, err := mcpServer.HandleJSONRPCRequest(messageBytes)
 		if err != nil {
 			logger.Error("MCP server error in batch", "error", err)
 			errorResponse := &common.MCPMessage{
 				JSONRpc: "2.0",
-				ID:      message.ID,
+				ID:      messageMap["id"],
 				Error: &common.MCPError{
 					Code:    -32603,
 					Message: "Internal error",
@@ -459,12 +490,12 @@ func handleBatchMessages(c echo.Context, messagesData []interface{}, session *MC
 			}
 			responses = append(responses, errorResponse)
 		} else {
-			var response common.MCPMessage
+			var response interface{}
 			if err := json.Unmarshal(responseBytes, &response); err != nil {
 				logger.Error("Failed to parse MCP response in batch", "error", err)
 				errorResponse := &common.MCPMessage{
 					JSONRpc: "2.0",
-					ID:      message.ID,
+					ID:      messageMap["id"],
 					Error: &common.MCPError{
 						Code:    -32603,
 						Message: "Parse error",
@@ -473,23 +504,19 @@ func handleBatchMessages(c echo.Context, messagesData []interface{}, session *MC
 				}
 				responses = append(responses, errorResponse)
 			} else {
-				responses = append(responses, &response)
+				responses = append(responses, response)
 			}
 		}
 	}
 
-	// Return batch responses
 	return c.JSON(http.StatusOK, responses)
 }
 
+// --- Server-Sent Events Support ---
+
 // handleMCPSSE handles Server-Sent Events for MCP connections (like Cline)
 func handleMCPSSE(c echo.Context) error {
-	// Check if this node is the leader
-	if err := checkLeaderMode(c); err != nil {
-		return err
-	}
-
-	// Get authentication token from 'token' header
+	// Validate authentication
 	token := c.Request().Header.Get("token")
 
 	// Validate token
@@ -530,10 +557,11 @@ func handleMCPSSE(c echo.Context) error {
 	c.Response().Header().Set("Connection", "keep-alive")
 	c.Response().Header().Set("Access-Control-Allow-Origin", "*")
 	c.Response().Header().Set("Access-Control-Allow-Headers", "token, Content-Type, Mcp-Session-Id")
+	c.Response().Header().Set(MCPSessionHeader, session.ID)
 
 	w := c.Response()
 
-	// Send initial connection notification (standard JSON-RPC notification)
+	// Send initial connection notification
 	connectionNotification := map[string]interface{}{
 		"jsonrpc": "2.0",
 		"method":  "notification/initialized",
@@ -566,9 +594,10 @@ func handleMCPSSE(c echo.Context) error {
 		select {
 		case <-done:
 			logger.Info("MCP SSE connection closed by client", "sessionId", session.ID)
+			deleteSession(session.ID)
 			return nil
 		case <-ticker.C:
-			// Send heartbeat as standard JSON-RPC notification
+			// Send heartbeat
 			heartbeat := map[string]interface{}{
 				"jsonrpc": "2.0",
 				"method":  "notification/ping",
@@ -584,9 +613,10 @@ func handleMCPSSE(c echo.Context) error {
 	}
 }
 
+// --- MCP Information Endpoints ---
+
 // MCP Server information endpoint (for discovery)
 func getMCPInfo(c echo.Context) error {
-	// Check if this node is the leader
 	if err := checkLeaderMode(c); err != nil {
 		return err
 	}
@@ -596,7 +626,7 @@ func getMCPInfo(c echo.Context) error {
 		"version":  common.MCPVersion,
 		"server": map[string]interface{}{
 			"name":    "AgentSmith-HUB",
-			"version": "1.0.0",
+			"version": "0.1.2",
 		},
 		"capabilities": map[string]interface{}{
 			"resources": map[string]interface{}{
@@ -609,7 +639,6 @@ func getMCPInfo(c echo.Context) error {
 			"prompts": map[string]interface{}{
 				"listChanged": true,
 			},
-			"logging": map[string]interface{}{},
 		},
 		"transport": "http",
 		"endpoint":  "/mcp",
@@ -617,6 +646,7 @@ func getMCPInfo(c echo.Context) error {
 			"is_leader": cluster.IsLeader,
 			"node_id":   cluster.NodeID,
 		},
+		"implementation": GetMCPImplementationStatus(),
 	}
 
 	return c.JSON(http.StatusOK, info)
@@ -624,46 +654,45 @@ func getMCPInfo(c echo.Context) error {
 
 // MCP Server manifest (for client discovery)
 func getMCPManifest(c echo.Context) error {
-	// Check if this node is the leader
 	if err := checkLeaderMode(c); err != nil {
 		return err
 	}
+
+	// Get current host for proper URLs
+	scheme := "http"
+	if c.Request().TLS != nil {
+		scheme = "https"
+	}
+	host := c.Request().Host
+	protocol := scheme
 
 	manifest := map[string]interface{}{
 		"mcpVersion":  common.MCPVersion,
 		"name":        "AgentSmith-HUB MCP Server",
 		"version":     "0.1.2",
-		"description": "Model Context Protocol server for AgentSmith-HUB Security Data Pipe Platform (SDPP) providing access to security project configurations, components, and security management tools (Leader node only)",
+		"description": "Model Context Protocol server for AgentSmith-HUB Security Data Pipe Platform providing comprehensive access to security management tools",
 		"author":      "AgentSmith-HUB Team",
 		"license":     "MIT",
 		"homepage":    "https://github.com/your-org/AgentSmith-HUB",
 		"transport": map[string]interface{}{
 			"type": "http",
-			"host": c.Request().Host,
+			"host": host,
 			"path": "/mcp",
 		},
 		"capabilities": map[string]interface{}{
-			"resources": []string{
-				"Projects and their configurations",
-				"Input component configurations",
-				"Output component configurations",
-				"Plugin source code and metadata",
-				"Ruleset XML configurations",
+			"resources": map[string]interface{}{
+				"description": "Access to project configurations, inputs, outputs, rulesets, and plugins",
+				"supported":   true,
 			},
-			"tools": []string{
-				"Full API coverage with 60+ tools for managing all HUB components",
-				"create_project - Create new projects",
-				"start_project - Start existing projects",
-				"stop_project - Stop running projects",
-				"get_project_status - Get project status information",
-				"search_components - Search through component configurations",
-				"validate_component - Validate component configurations",
-				"And many more management tools...",
+			"tools": map[string]interface{}{
+				"description": "Complete API access to all AgentSmith-HUB functionality",
+				"count":       len(mcpServer.GetAPIMapper().GetAllAPITools()),
+				"supported":   true,
 			},
-			"prompts": []string{
-				"analyze_project - Analyze project configurations",
-				"debug_component - Debug component issues",
-				"optimize_performance - Get performance optimization suggestions",
+			"prompts": map[string]interface{}{
+				"description": "Intelligent prompts for project analysis, debugging, optimization, and plugin development",
+				"count":       6,
+				"supported":   true,
 			},
 		},
 		"security": map[string]interface{}{
@@ -673,6 +702,11 @@ func getMCPManifest(c echo.Context) error {
 		"cluster": map[string]interface{}{
 			"leader_only": true,
 			"description": "MCP service is only available on cluster leader nodes",
+		},
+		"installation": map[string]interface{}{
+			"endpoint":    fmt.Sprintf("%s://%s/mcp", protocol, host),
+			"auth_header": "token",
+			"auth_value":  "your-auth-token-here",
 		},
 	}
 
@@ -741,19 +775,17 @@ func handleMCPBatch(c echo.Context) error {
 		},
 	})
 }
-
 // MCP Statistics endpoint
 func getMCPStats(c echo.Context) error {
-	// Check if this node is the leader
 	if err := checkLeaderMode(c); err != nil {
 		return err
 	}
 
-	// Collect statistics about MCP usage
 	stats := map[string]interface{}{
 		"server": map[string]interface{}{
-			"initialized": mcpServer != nil,
+			"initialized": mcpInitialized,
 			"version":     common.MCPVersion,
+			"library":     "mcp-go + custom handlers",
 		},
 		"cluster": map[string]interface{}{
 			"is_leader": cluster.IsLeader,
@@ -771,35 +803,22 @@ func getMCPStats(c echo.Context) error {
 			"tools_available":     true,
 			"prompts_available":   true,
 		},
-		"api_tools": map[string]interface{}{
+		"tools": map[string]interface{}{
 			"total_tools": len(mcpServer.GetAPIMapper().GetAllAPITools()),
 		},
+		"sessions": map[string]interface{}{
+			"active_count": len(mcpSessions),
+		},
+		"implementation": GetMCPImplementationStatus(),
 	}
 
 	return c.JSON(http.StatusOK, stats)
 }
 
-// getMCPInstallConfig provides MCP client installation configuration
-func getMCPInstallConfig(c echo.Context) error {
-	if !cluster.IsLeader {
-		return c.JSON(http.StatusForbidden, map[string]string{
-			"error": "MCP services are only available on the leader node",
-		})
-	}
-
-	// Get server host information
-	host := c.Request().Host
-	if host == "" {
-		host = "localhost:8080"
-	}
-
-	// Determine protocol (http/https)
-	protocol := "http"
-	if c.Request().TLS != nil {
-		protocol = "https"
-	}
-	if forwardedProto := c.Request().Header.Get("X-Forwarded-Proto"); forwardedProto != "" {
-		protocol = forwardedProto
+// Health check endpoint
+func mcpHealthCheck(c echo.Context) error {
+	if err := checkLeaderMode(c); err != nil {
+		return err
 	}
 
 	baseURL := fmt.Sprintf("%s://%s", protocol, host)
@@ -899,7 +918,7 @@ func getMCPInstallConfig(c echo.Context) error {
 		},
 	}
 
-	return c.JSON(http.StatusOK, mcpConfig)
+	return c.JSON(http.StatusOK, health)
 }
 
 // Helper function to extract port from host string

--- a/src/mcp/api_mapper.go
+++ b/src/mcp/api_mapper.go
@@ -87,7 +87,7 @@ func (m *APIMapper) GetAllAPITools() []common.MCPTool {
 		// 🔥 Component Lifecycle Management
 		{
 			Name:        "component_wizard",
-			Description: "🧙‍♂️ COMPONENT CREATION WIZARD: Guided component creation with templates, validation, and testing. Supports all component types with intelligent defaults and best practices.",
+			Description: GetToolDescription("component_wizard"),
 			InputSchema: map[string]common.MCPToolArg{
 				"component_type": {Type: "string", Description: "Component type: input/output/plugin/project/ruleset", Required: true},
 				"component_id":   {Type: "string", Description: "Component identifier", Required: true},
@@ -102,7 +102,7 @@ func (m *APIMapper) GetAllAPITools() []common.MCPTool {
 		// 🔥 System Intelligence
 		{
 			Name:        "system_overview",
-			Description: "🏠 SYSTEM DASHBOARD: Complete system status with health check, pending changes, active projects, and smart recommendations. Your one-stop system overview.",
+			Description: GetToolDescription("system_overview"),
 			InputSchema: map[string]common.MCPToolArg{
 				"include_metrics":     {Type: "string", Description: "Include performance metrics (true/false)", Required: false},
 				"include_suggestions": {Type: "string", Description: "Include optimization suggestions (true/false)", Required: false},
@@ -157,7 +157,7 @@ func (m *APIMapper) GetAllAPITools() []common.MCPTool {
 		// 🔥 Advanced Rule Management
 		{
 			Name:        "rule_manager",
-			Description: "🛡️ INTELLIGENT RULE MANAGER: Smart context-aware rule management → Auto-discovers target projects → Fetches relevant sample data → Analyzes data structure → Creates rules based on user intent + real data patterns. 🚨 CRITICAL: NEVER uses imagined data! All rules must be based on REAL sample data only!",
+			Description: GetToolDescription("rule_manager"),
 			InputSchema: map[string]common.MCPToolArg{
 				"action":          {Type: "string", Description: "Action: add_rule/update_rule/delete_rule/view_rules/create_ruleset/update_ruleset", Required: true},
 				"id":              {Type: "string", Description: "Target ruleset ID", Required: true},
@@ -177,7 +177,7 @@ func (m *APIMapper) GetAllAPITools() []common.MCPTool {
 
 		{
 			Name:        "test_lab",
-			Description: "🧪 COMPREHENSIVE TESTING LAB: Test any component with intelligent data samples, validation reports, and performance metrics. Supports batch testing and automated test suites.",
+			Description: GetToolDescription("test_lab"),
 			InputSchema: map[string]common.MCPToolArg{
 				"test_target":    {Type: "string", Description: "What to test: component/ruleset/project/workflow", Required: true},
 				"component_id":   {Type: "string", Description: "Component ID or 'all' for batch testing", Required: true},
@@ -193,7 +193,7 @@ func (m *APIMapper) GetAllAPITools() []common.MCPTool {
 
 		{
 			Name:        "deployment_center",
-			Description: "🚀 SMART DEPLOYMENT CENTER: View pending changes → Validate → Deploy with rollback capability. Includes deployment history, impact analysis, and automated testing.",
+			Description: GetToolDescription("deployment_center"),
 			InputSchema: map[string]common.MCPToolArg{
 				"action":           {Type: "string", Description: "Action: view_pending/validate/deploy/rollback/history", Required: true},
 				"component_filter": {Type: "string", Description: "Filter by component type (optional)", Required: false},
@@ -206,7 +206,7 @@ func (m *APIMapper) GetAllAPITools() []common.MCPTool {
 
 		{
 			Name:        "learning_center",
-			Description: "📚 DATA-DRIVEN LEARNING CENTER: Get templates, tutorials, and best practices. ⚠️ IMPORTANT: If backend has no sample data, guide users to provide their own real data for rule creation.",
+			Description: GetToolDescription("learning_center"),
 			InputSchema: map[string]common.MCPToolArg{
 				"resource_type": {Type: "string", Description: "Resource: samples (try to get backend data)/syntax_guide/templates/tutorials/best_practices", Required: true},
 				"component":     {Type: "string", Description: "Component focus: ruleset/input/output/plugin/project/all", Required: false},
@@ -235,7 +235,7 @@ func (m *APIMapper) GetAllAPITools() []common.MCPTool {
 
 		{
 			Name:        "smart_assistant",
-			Description: "🤖 AI-POWERED ASSISTANT: Get intelligent recommendations, troubleshoot issues, optimize configurations, and receive guided help for any task. Your personal AgentSmith expert. Use 'system_intro' task for complete architecture overview.",
+			Description: GetToolDescription("smart_assistant"),
 			InputSchema: map[string]common.MCPToolArg{
 				"task":        {Type: "string", Description: "What you want to accomplish or issue you're facing. Use 'system_intro' for complete AgentSmith-HUB overview.", Required: true},
 				"context":     {Type: "string", Description: "Current situation or component you're working with", Required: false},
@@ -750,7 +750,9 @@ func (m *APIMapper) handleCreateRuleWithValidation(args map[string]interface{}) 
 	}
 
 	var results []string
-	results = append(results, "=== DATA-DRIVEN RULE CREATION WORKFLOW ===\n")
+	results = append(results, GetWorkflowHeader("rule_creation", map[string]string{
+		"component_type": "rule",
+	}))
 	results = append(results, "✅ Sample data validation passed - proceeding with rule creation...")
 
 	// Step 1: Add the rule
@@ -800,21 +802,11 @@ func (m *APIMapper) handleCreateRuleWithValidation(args map[string]interface{}) 
 		results = append(results, fmt.Sprintf("✓ Usage analysis: %s\n", string(usageResponse)))
 	}
 
-	// Step 5: Deployment guidance
-	results = append(results, "\n=== 🚀 DEPLOYMENT GUIDANCE ===")
-	results = append(results, "⚠️  IMPORTANT: Your rule has been created in a TEMPORARY file and is NOT YET ACTIVE!")
-	results = append(results, "")
-	results = append(results, "📋 Next Steps Required:")
-	results = append(results, "1. 🔍 Check what's pending: Use 'get_pending_changes' to see all changes awaiting deployment")
-	results = append(results, "2. ✅ Apply changes: Use 'apply_changes' to deploy your rule to production")
-	results = append(results, "3. 🧪 Test thoroughly: Use 'test_ruleset' with real data to validate rule behavior")
-	results = append(results, "")
-	results = append(results, "🎯 Recommended Workflow:")
-	results = append(results, "   → get_pending_changes  (review what will be deployed)")
-	results = append(results, "   → apply_changes        (activate your rule)")
-	results = append(results, "   → test_ruleset         (verify it works correctly)")
-	results = append(results, "")
-	results = append(results, "💡 Your rule will remain inactive until you run 'apply_changes'!")
+	// Step 5: Deployment guidance using template
+	guidance := GetDeploymentGuidance("rule", "created", "ruleset")
+	for _, line := range guidance {
+		results = append(results, line)
+	}
 
 	return common.MCPToolResult{
 		Content: []common.MCPToolContent{{Type: "text", Text: strings.Join(results, "\n")}},
@@ -829,10 +821,15 @@ func (m *APIMapper) handleUpdateRuleSafely(args map[string]interface{}) (common.
 	testData, hasTestData := args["test_data"].(string)
 
 	var results []string
-	results = append(results, "=== SAFE RULE UPDATE WORKFLOW ===\n")
+	results = append(results, GetWorkflowHeader("rule_update", map[string]string{
+		"component_type": "rule",
+	}))
 
 	// Step 1: Get current ruleset for backup
-	results = append(results, "Step 1: Backing up current ruleset...")
+	results = append(results, GetStepTemplate("retrieving_data", map[string]string{
+		"step":      "1",
+		"component": "current ruleset for backup",
+	}))
 	_, err := m.makeHTTPRequest("GET", fmt.Sprintf("/rulesets/%s", rulesetId), nil, true)
 	if err != nil {
 		return common.MCPToolResult{
@@ -843,7 +840,10 @@ func (m *APIMapper) handleUpdateRuleSafely(args map[string]interface{}) (common.
 	results = append(results, "✓ Current ruleset backed up")
 
 	// Step 2: Delete old rule
-	results = append(results, "Step 2: Removing old rule...")
+	results = append(results, GetStepTemplate("creating_component", map[string]string{
+		"step":      "2",
+		"component": "old rule removal",
+	}))
 	deleteResponse, err := m.makeHTTPRequest("DELETE", fmt.Sprintf("/rulesets/%s/rules/%s", rulesetId, ruleId), nil, true)
 	if err != nil {
 		results = append(results, fmt.Sprintf("✗ Rule deletion failed: %v\n", err))
@@ -852,7 +852,10 @@ func (m *APIMapper) handleUpdateRuleSafely(args map[string]interface{}) (common.
 	}
 
 	// Step 3: Add new rule
-	results = append(results, "Step 3: Adding updated rule...")
+	results = append(results, GetStepTemplate("creating_component", map[string]string{
+		"step":      "3",
+		"component": "updated rule",
+	}))
 	addArgs := map[string]interface{}{
 		"id":       rulesetId,
 		"rule_raw": ruleRaw,
@@ -887,21 +890,11 @@ func (m *APIMapper) handleUpdateRuleSafely(args map[string]interface{}) (common.
 		}
 	}
 
-	// Step 6: Deployment guidance for rule updates
-	results = append(results, "\n=== 🚀 DEPLOYMENT GUIDANCE ===")
-	results = append(results, "⚠️  IMPORTANT: Your rule update has been saved to a TEMPORARY file and is NOT YET ACTIVE!")
-	results = append(results, "")
-	results = append(results, "📋 Next Steps Required:")
-	results = append(results, "1. 🔍 Review changes: Use 'get_pending_changes' to see all modifications awaiting deployment")
-	results = append(results, "2. ✅ Deploy update: Use 'apply_changes' to activate your updated rule in production")
-	results = append(results, "3. 🧪 Verify changes: Use 'test_ruleset' to ensure the updated rule works as expected")
-	results = append(results, "")
-	results = append(results, "🎯 Deployment Workflow:")
-	results = append(results, "   → get_pending_changes  (review what will be deployed)")
-	results = append(results, "   → apply_changes        (activate your updated rule)")
-	results = append(results, "   → test_ruleset         (verify the update works correctly)")
-	results = append(results, "")
-	results = append(results, "💡 The old rule version is still active until you run 'apply_changes'!")
+	// Step 6: Deployment guidance for rule updates using template
+	guidance := GetDeploymentGuidance("rule update", "saved", "ruleset")
+	for _, line := range guidance {
+		results = append(results, line)
+	}
 
 	return common.MCPToolResult{
 		Content: []common.MCPToolContent{{Type: "text", Text: strings.Join(results, "\n")}},
@@ -979,11 +972,16 @@ func (m *APIMapper) handleManageComponent(args map[string]interface{}) (common.M
 	testData, hasTestData := args["test_data"].(string)
 
 	var results []string
-	results = append(results, fmt.Sprintf("=== COMPLETE %s MANAGEMENT WORKFLOW ===\n", strings.ToUpper(componentType)))
+	results = append(results, GetWorkflowHeader("component_management", map[string]string{
+		"component_type": strings.ToUpper(componentType),
+	}))
 
 	// Step 1: Create component if operation is "create"
 	if operation == "create" {
-		results = append(results, "Step 1: Creating component...")
+		results = append(results, GetStepTemplate("creating_component", map[string]string{
+			"step":      "1",
+			"component": componentType,
+		}))
 		createArgs := map[string]interface{}{
 			"id":  componentId,
 			"raw": rawContent,
@@ -999,7 +997,10 @@ func (m *APIMapper) handleManageComponent(args map[string]interface{}) (common.M
 	}
 
 	// Step 2: Verify component
-	results = append(results, "Step 2: Verifying component...")
+	results = append(results, GetStepTemplate("verifying_component", map[string]string{
+		"step":      "2",
+		"component": componentType,
+	}))
 	verifyResponse, err := m.makeHTTPRequest("POST", fmt.Sprintf("/verify/%s/%s", componentType, componentId), nil, true)
 	if err != nil {
 		results = append(results, fmt.Sprintf("✗ Verification failed: %v\n", err))
@@ -1056,25 +1057,11 @@ func (m *APIMapper) handleManageComponent(args map[string]interface{}) (common.M
 	} else {
 		results = append(results, "Step 5: Component created in temporary file")
 
-		// Add deployment guidance
-		results = append(results, "\n=== 🚀 DEPLOYMENT GUIDANCE ===")
-		results = append(results, fmt.Sprintf("⚠️  IMPORTANT: Your %s has been created in a TEMPORARY file and is NOT YET ACTIVE!", strings.ToUpper(componentType)))
-		results = append(results, "")
-		results = append(results, "📋 Next Steps Required:")
-		results = append(results, "1. 🔍 Review changes: Use 'get_pending_changes' to see all components awaiting deployment")
-		results = append(results, "2. ✅ Deploy component: Use 'apply_changes' to activate your component in production")
-		if componentType == "input" || componentType == "output" {
-			results = append(results, "3. 🔗 Test connectivity: Use 'connect_check' to verify connection to external systems")
+		// Add deployment guidance using template
+		guidance := GetDeploymentGuidance(componentType, "created", componentType)
+		for _, line := range guidance {
+			results = append(results, line)
 		}
-		if componentType == "plugin" {
-			results = append(results, "3. 🧪 Test plugin: Use 'test_plugin' to verify plugin functionality")
-		}
-		results = append(results, "")
-		results = append(results, "🎯 Deployment Workflow:")
-		results = append(results, "   → get_pending_changes  (review what will be deployed)")
-		results = append(results, "   → apply_changes        (activate your component)")
-		results = append(results, "")
-		results = append(results, "💡 Your component will remain inactive until you run 'apply_changes'!")
 	}
 
 	return common.MCPToolResult{
@@ -1088,10 +1075,15 @@ func (m *APIMapper) handleSystemHealthCheck(args map[string]interface{}) (common
 	checkDependencies, shouldCheckDeps := args["check_dependencies"].(string)
 
 	var results []string
-	results = append(results, "=== COMPREHENSIVE SYSTEM HEALTH CHECK ===\n")
+	results = append(results, GetWorkflowHeader("system_health", map[string]string{
+		"component_type": "system",
+	}))
 
 	// Step 1: Cluster health
-	results = append(results, "Step 1: Checking cluster health...")
+	results = append(results, GetStepTemplate("verifying_component", map[string]string{
+		"step":      "1",
+		"component": "cluster health",
+	}))
 	clusterResponse, err := m.makeHTTPRequest("GET", "/cluster-status", nil, false)
 	if err != nil {
 		results = append(results, fmt.Sprintf("✗ Cluster health check failed: %v\n", err))
@@ -1100,7 +1092,10 @@ func (m *APIMapper) handleSystemHealthCheck(args map[string]interface{}) (common
 	}
 
 	// Step 2: All projects health
-	results = append(results, "Step 2: Checking all projects...")
+	results = append(results, GetStepTemplate("verifying_component", map[string]string{
+		"step":      "2",
+		"component": "all projects",
+	}))
 	projectsResponse, err := m.makeHTTPRequest("GET", "/projects", nil, true)
 	if err != nil {
 		results = append(results, fmt.Sprintf("✗ Projects health check failed: %v\n", err))
@@ -1109,7 +1104,10 @@ func (m *APIMapper) handleSystemHealthCheck(args map[string]interface{}) (common
 	}
 
 	// Step 3: System resources
-	results = append(results, "Step 3: Checking system resources...")
+	results = append(results, GetStepTemplate("verifying_component", map[string]string{
+		"step":      "3",
+		"component": "system resources",
+	}))
 	systemResponse, err := m.makeHTTPRequest("GET", "/system-metrics", nil, false)
 	if err != nil {
 		results = append(results, fmt.Sprintf("✗ System metrics check failed: %v\n", err))
@@ -1652,7 +1650,10 @@ func (m *APIMapper) handleAddRulesetRule(args map[string]interface{}) (common.MC
 	results = append(results, "=== RULE ADDITION ===\n")
 
 	// Step 1: Add rule
-	results = append(results, "Step 1: Adding rule to ruleset...")
+	results = append(results, GetStepTemplate("creating_component", map[string]string{
+		"step":      "1",
+		"component": "rule to ruleset",
+	}))
 	addArgs := map[string]interface{}{
 		"rule_raw": ruleRaw,
 	}


### PR DESCRIPTION
- Refactor mcp_handlers.go to use unified StandardMCPServer approach
- Simplify StandardMCPServer while preserving mcp-go library dependency
- Unify MCP configuration management in config_provider.go
- Add missing LoadMCPPrompts and GetMCPPrompt functions
- Remove duplicate JSON-RPC handling and tool migration logic
- Add MCP configuration endpoints to server routes
- Fix plugin creation templates with correct function signatures
- Add comprehensive plugin creation prompts with strict requirements
- Update both frontend and backend plugin templates to use proper Eval signature