### PR TITLE
fix: optimize instruction compression logic by simplifying loop structure

### DIFF
--- a/src/cluster/instruction_sync.go
+++ b/src/cluster/instruction_sync.go
@@ -166,18 +166,15 @@ func (im *InstructionManager) CompactAndSaveInstructions(new *Instruction) error
 			continue
 		}
 
-		for i2, ii2 := range instructions {
-			if i != i2 {
-				if (ii.ComponentType == ii2.ComponentType) && (ii.ComponentName == ii2.ComponentName) {
-					if CUD_OPERATION[ii.Operation] && CUD_OPERATION[ii2.Operation] {
-						delInstructions[i] = true
-						break
-					} else if PROJECT_OPERATION[ii.Operation] && PROJECT_OPERATION[ii2.Operation] {
-						if i < i2 {
-							delInstructions[i] = true
-						}
-						break
-					}
+		for i2 := i + 1; i2 < len(instructions); i2++ {
+			ii2 := instructions[i2]
+			if (ii.ComponentType == ii2.ComponentType) && (ii.ComponentName == ii2.ComponentName) {
+				if CUD_OPERATION[ii.Operation] && CUD_OPERATION[ii2.Operation] {
+					delInstructions[i] = true
+					break
+				} else if PROJECT_OPERATION[ii.Operation] && PROJECT_OPERATION[ii2.Operation] {
+					delInstructions[i] = true
+					break
 				}
 			}
 		}


### PR DESCRIPTION
- Refactor the loop for comparing instructions to improve readability and performance.
- Ensure correct deletion of instructions based on component type and name comparisons.

For current version, the latest cud operation instruction could be compacted, that causes cluster state corruption:
<img width="1692" height="156" alt="image" src="https://github.com/user-attachments/assets/ee949fa9-bc0c-463f-8c89-7ef1dd631b42" />
