### PR TITLE
Fix Project Instruction Creation Failure in Version Compaction Scenarios

### DIFF
--- a/src/cluster/instruction_sync.go
+++ b/src/cluster/instruction_sync.go
@@ -378,7 +378,7 @@ func (im *InstructionManager) InitializeLeaderInstructions() error {
 
 	_, err := im.setCurrentVersion(0)
 	if err != nil {
-		err = fmt.Errorf("Failed to write leader version to Redis during initialization", "error", err)
+		err = fmt.Errorf("failed to write leader version to Redis during initialization: %w", err)
 		return err
 	}
 


### PR DESCRIPTION
### Summary

This PR addresses Project component creation failures during instruction version compaction by implementing local sorting in the synchronization process. The fix ensures that Project instructions are processed only after all their dependencies (Input, Output, Ruleset components) have been successfully synchronized.

### Problem

During instruction version compaction, Project components could fail to be created when syncing instructions in strict version order. This issue occurs because:

1. Project components depend on other components (Input, Output, Ruleset) while other components have no inter-dependencies
2. In version compaction scenarios, if dependencies are processed out of order, Project instructions may fail during creation
3. This problem becomes more significant when new Followers join the cluster

Example scenario that demonstrates the issue:
1. add input a
2. add output b  
3. add ruleset c (compacted by 6)
4. add project
5. start project
6. push_change ruleset c

In this flow:
- Version 3 fails during sync due to compaction
- Version 4 fails during Apply because ruleset c doesn't exist
- Although version 6 succeeds, the project doesn't reach the expected state

### Solution

Implemented local sorting during instruction synchronization to prioritize non-project component versions for synchronization first, then process project-related versions only after all dependencies are ready. This ensures that all required components (inputs, outputs, rulesets) are properly synchronized before any project instructions are processed, maintaining dependency integrity during cluster synchronization.

### Changes

- Modified `SyncInstructions` function in `src/cluster/sync_listener.go` to sort instructions by component type
- Added stable sorting logic using `slices.SortStableFunc` that processes project instructions after all other component types, maintains original version ordering.
- No changes to instruction format or existing APIs
