### PR TITLE
Add OIDC (OpenID Connect) SSO, unify authentication, and expose runtime auth config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ src/.token
 
 # Kubernetes secrets
 k8s/secrets.yaml
+web/pnpm-lock.yaml

--- a/docs/agentsmith-hub-guide-zh.md
+++ b/docs/agentsmith-hub-guide-zh.md
@@ -360,6 +360,52 @@ AgentSmith-HUB 支持 MCP，Token 于 Server 共同，以下是 Cline 配置：
 目前可以通过 MCP 覆盖了大部分使用场景，包括策略编辑等。
 ![MCP.png](png/MCP.png)
 
+### 2.6 认证与登录（OIDC 单点登录）
+
+AgentSmith-HUB 支持两种认证方式：
+
+- 传统 Token：在请求头携带 `token: <your-token>`（保留兼容）；
+- OIDC（OpenID Connect）：浏览器完成登录后使用 Bearer ID Token，后端验证后放行。
+
+后端公开 `GET /auth/config` 供前端在运行时获取 OIDC 配置；前端在启用 OIDC 时，登录页会显示“Use Single Sign-On”按钮，回调路径默认 `/oidc/callback`。
+
+#### 后端配置（config.yaml）
+
+```yaml
+oidc_enabled: true
+oidc_issuer: "https://your-idp/realms/your-realm"   # Issuer（可为 OIDC 发现端点对应的 Issuer）
+oidc_client_id: "agentsmith-web"                    # 在 IdP 中注册的客户端 ID
+oidc_redirect_uri: "https://hub.example.com/oidc/callback"  # 必须在 IdP 客户端允许列表中
+oidc_username_claim: "preferred_username"           # 可选，默认优先 preferred_username，否则 email
+oidc_allowed_users: ["alice@example.com", "bob"]    # 可选，限制允许访问的用户名（为空表示禁止任何人登录）
+oidc_scope: "openid profile email"                   # 可选，默认为 openid profile email
+```
+
+也可通过环境变量覆盖（优先级更高）：
+
+```bash
+OIDC_ENABLED=true
+OIDC_ISSUER=https://your-idp/realms/your-realm
+OIDC_CLIENT_ID=agentsmith-web
+OIDC_REDIRECT_URI=https://hub.example.com/oidc/callback
+OIDC_USERNAME_CLAIM=preferred_username
+OIDC_ALLOWED_USERS=alice@example.com,bob
+OIDC_SCOPE="openid profile email"
+```
+
+注意：
+
+- `oidc_enabled: true` 时必须同时配置 `oidc_issuer`、`oidc_client_id`、`oidc_redirect_uri`；
+- `oidc_redirect_uri` 必须与 IdP 客户端配置完全一致；如 Hub 位于反向代理/子路径下，请据实设置完整回调地址（例如 `https://hub.example.com/subpath/oidc/callback`），并在 IdP 端放行；
+- 用户名判定优先使用 `preferred_username`，找不到则使用 `email`；可通过 `oidc_username_claim` 显式指定；
+- 如配置了 `oidc_allowed_users`，仅名单内用户可访问；为空表示禁止任何人登录；
+- 传统 Token 方式仍受支持，MCP 与脚本集成可继续使用 `token` 请求头。
+
+前端说明：前端默认从后端 `GET /auth/config` 动态获取 OIDC 配置，一般无需在前端写死;
+
+回调路由：`/oidc/callback`
+
+
 ## 📚 第三部分：RULESET 语法详解
 
 ### 3.1 你的第一个规则

--- a/src/api/auth.go
+++ b/src/api/auth.go
@@ -1,0 +1,150 @@
+package api
+
+import (
+	"AgentSmith-HUB/common"
+	"AgentSmith-HUB/logger"
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"sync"
+
+	"github.com/coreos/go-oidc/v3/oidc"
+	"github.com/labstack/echo/v4"
+)
+
+// Public response for frontend to decide login flow
+type AuthConfigResponse struct {
+	OIDCEnabled   bool   `json:"oidc_enabled"`
+	Issuer        string `json:"issuer,omitempty"`
+	ClientID      string `json:"client_id,omitempty"`
+	UsernameClaim string `json:"username_claim,omitempty"`
+	RedirectURI   string `json:"redirect_uri,omitempty"`
+	Scope         string `json:"scope,omitempty"`
+}
+
+var (
+	oidcOnce      sync.Once
+	oidcInitErr   error
+	oidcProvider  *oidc.Provider
+	idTokenVerify *oidc.IDTokenVerifier
+)
+
+func ensureOIDCVerifier(ctx context.Context) error {
+	oidcOnce.Do(func() {
+		if !common.Config.OIDCEnabled {
+			oidcInitErr = nil
+			return
+		}
+		if common.Config.OIDCIssuer == "" || common.Config.OIDCClientID == "" {
+			oidcInitErr = errors.New("OIDC issuer or client_id not configured")
+			return
+		}
+		provider, err := oidc.NewProvider(ctx, common.Config.OIDCIssuer)
+		if err != nil {
+			oidcInitErr = err
+			return
+		}
+		oidcProvider = provider
+		verifier := provider.Verifier(&oidc.Config{ClientID: common.Config.OIDCClientID})
+		idTokenVerify = verifier
+	})
+	return oidcInitErr
+}
+
+// VerifyOIDCToken verifies an ID token and returns claims map
+func VerifyOIDCToken(ctx context.Context, rawToken string) (map[string]interface{}, error) {
+	if !common.Config.OIDCEnabled {
+		return nil, errors.New("OIDC not enabled")
+	}
+	if err := ensureOIDCVerifier(ctx); err != nil {
+		return nil, err
+	}
+	if idTokenVerify == nil {
+		return nil, errors.New("OIDC verifier not initialized")
+	}
+	idTok, err := idTokenVerify.Verify(ctx, rawToken)
+	if err != nil {
+		return nil, err
+	}
+	var claims map[string]interface{}
+	if err := idTok.Claims(&claims); err != nil {
+		return nil, err
+	}
+	return claims, nil
+}
+
+func isUserAllowed(claims map[string]interface{}) bool {
+	allowed := common.Config.OIDCAllowedUsers
+	if len(allowed) == 0 {
+		return false
+	}
+	claimKey := common.Config.OIDCUsernameClaim
+	if claimKey == "" {
+		// default fallbacks
+		if _, ok := claims["preferred_username"]; ok {
+			claimKey = "preferred_username"
+		} else {
+			claimKey = "email"
+		}
+	}
+	val, _ := claims[claimKey].(string)
+	if val == "" {
+		return false
+	}
+	for _, u := range allowed {
+		if strings.EqualFold(strings.TrimSpace(u), val) {
+			return true
+		}
+	}
+	return false
+}
+
+// AuthenticateRequest allows either legacy token header or OIDC Bearer token
+func AuthenticateRequest(c echo.Context) error {
+	// Legacy token header
+	token := c.Request().Header.Get("token")
+	if token != "" && token == common.Config.Token {
+		return nil
+	}
+
+	// OIDC Bearer token
+	authz := c.Request().Header.Get("Authorization")
+	if authz == "" {
+		return errors.New("empty authorization header")
+	}
+	if !strings.HasPrefix(strings.ToLower(authz), "bearer ") {
+		return errors.New("invalid authorization header")
+	}
+	raw := strings.TrimSpace(authz[len("Bearer "):])
+	if raw == "" {
+		return errors.New("empty bearer token")
+	}
+
+	if !common.Config.OIDCEnabled {
+		return errors.New("oidc not enabled")
+	}
+
+	claims, err := VerifyOIDCToken(c.Request().Context(), raw)
+	if err != nil {
+		logger.Warn("OIDC token verification failed", "error", err)
+		return errors.New("authentication failed")
+	}
+	if !isUserAllowed(claims) {
+		return errors.New("user not allowed")
+	}
+	return nil
+}
+
+// GET /auth/config
+func getAuthConfig(c echo.Context) error {
+	resp := AuthConfigResponse{
+		OIDCEnabled:   common.Config.OIDCEnabled,
+		Issuer:        common.Config.OIDCIssuer,
+		ClientID:      common.Config.OIDCClientID,
+		UsernameClaim: common.Config.OIDCUsernameClaim,
+		RedirectURI:   common.Config.OIDCRedirectURI,
+		Scope:         common.Config.OIDCScope,
+	}
+	return c.JSON(http.StatusOK, resp)
+}

--- a/src/common/types.go
+++ b/src/common/types.go
@@ -32,6 +32,14 @@ type HubConfig struct {
 	Leader        string
 	LocalIP       string
 	Token         string
+	// OIDC/OAuth2 configuration
+	OIDCEnabled       bool     `yaml:"oidc_enabled"`
+	OIDCIssuer        string   `yaml:"oidc_issuer"`
+	OIDCClientID      string   `yaml:"oidc_client_id"`
+	OIDCUsernameClaim string   `yaml:"oidc_username_claim"`
+	OIDCAllowedUsers  []string `yaml:"oidc_allowed_users"`
+	OIDCRedirectURI   string   `yaml:"oidc_redirect_uri"`
+	OIDCScope         string   `yaml:"oidc_scope"`
 }
 
 // Operation types for project operations

--- a/src/go.mod
+++ b/src/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/aliyun/aliyun-log-go-sdk v0.1.106
 	github.com/bytedance/sonic v1.13.3
 	github.com/cespare/xxhash/v2 v2.3.0
+	github.com/coreos/go-oidc/v3 v3.11.0
 	github.com/dgraph-io/ristretto/v2 v2.2.0
 	github.com/elastic/go-elasticsearch/v8 v8.18.1
 	github.com/google/uuid v1.6.0
@@ -26,7 +27,11 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 )
 
-require google.golang.org/genproto/googleapis/rpc v0.0.0-20250728155136-f173205681a0 // indirect
+require (
+	github.com/go-jose/go-jose/v4 v4.0.2 // indirect
+	golang.org/x/oauth2 v0.30.0 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20250728155136-f173205681a0 // indirect
+)
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect

--- a/src/go.sum
+++ b/src/go.sum
@@ -90,6 +90,8 @@ github.com/clbanning/mxj/v2 v2.7.0/go.mod h1:hNiWqW14h+kc+MdF9C6/YoRfjEJoR3ou6tn
 github.com/cloudwego/base64x v0.1.5 h1:XPciSp1xaq2VCSt6lF0phncD4koWyULpl5bUxbfCyP4=
 github.com/cloudwego/base64x v0.1.5/go.mod h1:0zlkT4Wn5C6NdauXdJRhSKRlJvmclQ1hhJgA0rcu/8w=
 github.com/cloudwego/iasm v0.2.0/go.mod h1:8rXZaNYT2n95jn+zTI1sDr+IgcD2GVs0nlbbQPiEFhY=
+github.com/coreos/go-oidc/v3 v3.11.0 h1:Ia3MxdwpSw702YW0xgfmP1GVCMA9aEFWu12XUZ3/OtI=
+github.com/coreos/go-oidc/v3 v3.11.0/go.mod h1:gE3LgjOgFoHi9a4ce4/tJczr0Ai2/BoDhf0r5lltWI0=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
@@ -112,6 +114,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
+github.com/go-jose/go-jose/v4 v4.0.2 h1:R3l3kkBds16bO7ZFAEEcofK0MkrAJt3jlJznWZG0nvk=
+github.com/go-jose/go-jose/v4 v4.0.2/go.mod h1:WVf9LFMHh/QVrmqrOfqun0C45tMe3RoiKJMPvgWwLfY=
 github.com/go-kit/kit v0.13.0 h1:OoneCcHKHQ03LfBpoQCUfCluwd2Vt3ohz+kvbJneZAU=
 github.com/go-kit/kit v0.13.0/go.mod h1:phqEHMMUbyrCFCTgH48JueqrM3md2HcAZ8N3XE4FKDg=
 github.com/go-kit/log v0.2.1 h1:MRVx0/zhvdseW+Gza6N9rVzU/IVzaeE1SFI4raAhmBU=

--- a/web/CONFIG_GUIDE.md
+++ b/web/CONFIG_GUIDE.md
@@ -103,6 +103,22 @@ If no other configuration is provided, the system will use built-in default conf
 - `theme`: Theme setting (`light` | `dark`)
 - `language`: Language setting (`en` | `zh`)
 
+### Authentication (OIDC)
+
+The frontend initializes OIDC based on backend runtime config from `GET /auth/config`. Usually no build-time values are needed. If you need static values at build time (optional), set:
+
+```env
+# VITE_OIDC_ISSUER=https://your-idp/.well-known/openid-configuration
+# VITE_OIDC_CLIENT_ID=agentsmith-web
+```
+
+At runtime, the backend must be configured with:
+
+- `OIDC_ENABLED`, `OIDC_ISSUER`, `OIDC_CLIENT_ID`, `OIDC_REDIRECT_URI` (required when enabled)
+- Optional: `OIDC_USERNAME_CLAIM`, `OIDC_ALLOWED_USERS`, `OIDC_SCOPE`
+
+The login page shows an SSO button when OIDC is enabled. Default callback route is `/oidc/callback`.
+
 ## Deployment Scenarios
 
 ### Scenario 1: Containerized Deployment

--- a/web/env.example
+++ b/web/env.example
@@ -27,3 +27,8 @@ VITE_LANGUAGE=en
 # VITE_API_TIMEOUT=60000
 # VITE_DEBUG_MODE=false
 # VITE_CLUSTER_MODE=true 
+
+# OIDC (Frontend)
+# These are optional because backend exposes /auth/config at runtime. If you need static values:
+# VITE_OIDC_ISSUER=https://your-idp/.well-known/openid-configuration
+# VITE_OIDC_CLIENT_ID=agentsmith-web

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -33,6 +33,7 @@
         "js-yaml": "^4.1.0",
         "markdown-it": "^14.1.0",
         "monaco-editor": "^0.52.2",
+        "oidc-client-ts": "^3.0.3",
         "pinia": "^3.0.3",
         "prismjs": "^1.30.0",
         "vue": "^3.3.0",
@@ -4689,6 +4690,14 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "license": "MIT"
     },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmmirror.com/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/lilconfig": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
@@ -4946,6 +4955,17 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/oidc-client-ts": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmmirror.com/oidc-client-ts/-/oidc-client-ts-3.3.0.tgz",
+      "integrity": "sha512-t13S540ZwFOEZKLYHJwSfITugupW4uYLwuQSSXyKH/wHwZ+7FvgHE7gnNJh1YQIZ1Yd1hKSRjqeXGSUtS0r9JA==",
+      "dependencies": {
+        "jwt-decode": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/package-json-from-dist": {

--- a/web/package.json
+++ b/web/package.json
@@ -24,6 +24,7 @@
     "@vue-flow/core": "^1.44.0",
     "@vue-flow/minimap": "^1.5.3",
     "axios": "^1.6.0",
+    "oidc-client-ts": "^3.0.3",
     "codemirror": "^6.0.1",
     "dagre": "^0.8.5",
     "esbuild": "^0.25.5",

--- a/web/public/agentsmith-hub-guide-zh.md
+++ b/web/public/agentsmith-hub-guide-zh.md
@@ -355,7 +355,53 @@ AgentSmith-HUB 支持 MCP，Token 于 Server 共同，以下是 Cline 配置：
 ```
 
 目前可以通过 MCP 覆盖了大部分使用场景，包括策略编辑等。
-![MCP.png](/png/MCP.png)
+![MCP.png](png/MCP.png)
+
+### 2.6 认证与登录（OIDC 单点登录）
+
+AgentSmith-HUB 支持两种认证方式：
+
+- 传统 Token：在请求头携带 `token: <your-token>`（保留兼容）；
+- OIDC（OpenID Connect）：浏览器完成登录后使用 Bearer ID Token，后端验证后放行。
+
+后端公开 `GET /auth/config` 供前端在运行时获取 OIDC 配置；前端在启用 OIDC 时，登录页会显示“Use Single Sign-On”按钮，回调路径默认 `/oidc/callback`。
+
+#### 后端配置（config.yaml）
+
+```yaml
+oidc_enabled: true
+oidc_issuer: "https://your-idp/realms/your-realm"   # Issuer（可为 OIDC 发现端点对应的 Issuer）
+oidc_client_id: "agentsmith-web"                    # 在 IdP 中注册的客户端 ID
+oidc_redirect_uri: "https://hub.example.com/oidc/callback"  # 必须在 IdP 客户端允许列表中
+oidc_username_claim: "preferred_username"           # 可选，默认优先 preferred_username，否则 email
+oidc_allowed_users: ["alice@example.com", "bob"]    # 可选，限制允许访问的用户名（为空表示禁止任何人登录）
+oidc_scope: "openid profile email"                   # 可选，默认为 openid profile email
+```
+
+也可通过环境变量覆盖（优先级更高）：
+
+```bash
+OIDC_ENABLED=true
+OIDC_ISSUER=https://your-idp/realms/your-realm
+OIDC_CLIENT_ID=agentsmith-web
+OIDC_REDIRECT_URI=https://hub.example.com/oidc/callback
+OIDC_USERNAME_CLAIM=preferred_username
+OIDC_ALLOWED_USERS=alice@example.com,bob
+OIDC_SCOPE="openid profile email"
+```
+
+注意：
+
+- `oidc_enabled: true` 时必须同时配置 `oidc_issuer`、`oidc_client_id`、`oidc_redirect_uri`；
+- `oidc_redirect_uri` 必须与 IdP 客户端配置完全一致；如 Hub 位于反向代理/子路径下，请据实设置完整回调地址（例如 `https://hub.example.com/subpath/oidc/callback`），并在 IdP 端放行；
+- 用户名判定优先使用 `preferred_username`，找不到则使用 `email`；可通过 `oidc_username_claim` 显式指定；
+- 如配置了 `oidc_allowed_users`，仅名单内用户可访问；为空表示禁止任何人登录；
+- 传统 Token 方式仍受支持，MCP 与脚本集成可继续使用 `token` 请求头。
+
+前端说明：前端默认从后端 `GET /auth/config` 动态获取 OIDC 配置，一般无需在前端写死;
+
+回调路由：`/oidc/callback`
+
 
 ## 📚 第三部分：RULESET 语法详解
 

--- a/web/public/agentsmith-hub-guide.md
+++ b/web/public/agentsmith-hub-guide.md
@@ -357,7 +357,55 @@ AgentSmith-HUB supports MCP, with tokens shared on the server. The following is 
 ```
 
 Currently, MCP covers most use cases, including policy editing, etc.
-![MCP.png](/png/MCP.png)
+![MCP.png](png/MCP.png)
+
+### 2.6 Authentication and Login (OIDC SSO)
+
+AgentSmith-HUB supports two authentication methods:
+
+- Legacy Token: send `token: <your-token>` in request headers (kept for compatibility);
+- OIDC (OpenID Connect): the browser completes login and uses Bearer ID Token; the backend verifies it.
+
+The backend exposes `GET /auth/config` so the frontend can load OIDC settings at runtime. When OIDC is enabled, the login page shows a “Use Single Sign-On” button. The default callback route is `/oidc/callback`.
+
+#### Backend configuration (config.yaml)
+
+```yaml
+oidc_enabled: true
+oidc_issuer: "https://your-idp/realms/your-realm"   # Issuer for your IdP
+oidc_client_id: "agentsmith-web"                    # Client ID registered at IdP
+oidc_redirect_uri: "https://hub.example.com/oidc/callback"  # Must be allowed in IdP
+oidc_username_claim: "preferred_username"           # Optional; default prefers preferred_username, else email
+oidc_allowed_users: ["alice@example.com", "bob"]    # Optional allowlist; empty means nobody will allow
+oidc_scope: "openid profile email"                   # Optional; default openid profile email
+```
+
+You can also override via environment variables (higher priority):
+
+```bash
+OIDC_ENABLED=true
+OIDC_ISSUER=https://your-idp/realms/your-realm
+OIDC_CLIENT_ID=agentsmith-web
+OIDC_REDIRECT_URI=https://hub.example.com/oidc/callback
+OIDC_USERNAME_CLAIM=preferred_username
+OIDC_ALLOWED_USERS=alice@example.com,bob
+OIDC_SCOPE="openid profile email"
+```
+
+Notes:
+
+- When `oidc_enabled: true`, you must set `oidc_issuer`, `oidc_client_id`, and `oidc_redirect_uri`.
+- `oidc_redirect_uri` must exactly match the IdP client configuration. If Hub is behind a reverse proxy or served under a subpath, set the full callback URL accordingly (e.g., `https://hub.example.com/subpath/oidc/callback`) and allow it at the IdP.
+- Username resolution prefers `preferred_username`, then falls back to `email`; override with `oidc_username_claim` if needed.
+- If `oidc_allowed_users` is set, only listed users can access; leave empty to deny anyone.
+- Legacy Token remains supported for MCP and automation via the `token` header.
+
+Frontend:
+
+The frontend loads OIDC configuration from `GET /auth/config` by default, so no static values are required.
+
+Callback route: `/oidc/callback`
+
 
 ## 📚 Part 3: RULESET Syntax Detailed Explanation
 

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -25,7 +25,7 @@ onMounted(() => {
   // Keep global variable for compatibility
   window.$toast = toast.value
   // Fetch available plugins using unified cache
-  dataCache.fetchAvailablePlugins()
+  // dataCache.fetchAvailablePlugins()
 })
 </script>
 

--- a/web/src/api/oidc.js
+++ b/web/src/api/oidc.js
@@ -1,0 +1,43 @@
+import { UserManager, WebStorageStateStore } from "oidc-client-ts";
+import { hubApi } from "./index.js";
+
+let userManager = null;
+let oidcEnabled = false;
+
+export async function initOidc() {
+  if (userManager) return userManager; // 已初始化
+
+  // 从后端获取配置
+  const cfg = await hubApi.getAuthConfig();
+  if (!cfg.oidc_enabled){
+    return;
+  }
+
+  // 组装 oidc-client-ts 配置
+  const oidcConfig = {
+    authority: cfg.issuer,
+    client_id: cfg.client_id,
+    // Prefer configured callback, fallback to our router path
+    redirect_uri: cfg.redirect_uri || (window.location.origin + "/oidc/callback"),
+    post_logout_redirect_uri: cfg.post_logout_redirect_uri || window.location.origin,
+    response_type: "code",
+    scope: cfg.scope || "openid profile email",
+    loadUserInfo: true,
+    userStore: new WebStorageStateStore({ store: window.sessionStorage }),
+  };
+
+  userManager = new UserManager(oidcConfig);
+  oidcEnabled = true;
+  return userManager;
+}
+
+export function getUserManager() {
+  if (!userManager) {
+    throw new Error("OIDC 尚未初始化，请先调用 initOidc()");
+  }
+  return userManager;
+}
+
+export function isOidcEnabled() {
+  return oidcEnabled;
+}

--- a/web/src/components/Header.vue
+++ b/web/src/components/Header.vue
@@ -27,12 +27,17 @@
 
 <script>
 import { hubApi } from '../api';
+import { getUserManager } from '../api/oidc';
 
 export default {
   name: 'Header',
   methods: {
     logout() {
       hubApi.clearToken();
+      try {
+        // Avoid throwing if OIDC not initialized
+        getUserManager().removeUser();
+      } catch (e) {}
       this.$router.push('/');
     },
     openGitHub() {

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -6,6 +6,7 @@ import router from './router/index.js'
 import store from './store/index.js'
 import './monaco-loader.js'
 import { initializeConfig } from './config/index.js'
+import { initOidc } from './api/oidc.js'
 
 // Initialize configuration before creating the app
 async function initializeApp() {
@@ -13,6 +14,8 @@ async function initializeApp() {
     // Load runtime configuration
     await initializeConfig()
     console.log('Configuration initialized successfully')
+    await initOidc(); // 在配置加载后初始化 OIDC（需要已知的回调 URL 等）
+    console.log('OIDC initialized successfully')
   } catch (error) {
     console.warn('Failed to initialize configuration:', error)
     // Continue with default configuration

--- a/web/src/router/index.js
+++ b/web/src/router/index.js
@@ -1,5 +1,6 @@
 import { createRouter, createWebHistory } from 'vue-router';
 import Login from '../views/Login.vue';
+const OidcCallback = () => import('../views/OidcCallback.vue');
 import MainLayout from '../views/MainLayout.vue';
 import Dashboard from '../views/Dashboard.vue';
 import ComponentDetail from '../components/ComponentDetail.vue';
@@ -16,6 +17,11 @@ const routes = [
     path: '/login',
     name: 'LoginPage',
     component: Login,
+  },
+  {
+    path: '/oidc/callback',
+    name: 'OidcCallback',
+    component: OidcCallback,
   },
   {
     path: '/dashboard',
@@ -133,7 +139,7 @@ const router = createRouter({
 });
 
 router.beforeEach(async (to, from, next) => {
-  const token = localStorage.getItem('auth_token');
+  const token = localStorage.getItem('auth_token') || localStorage.getItem('auth_bearer');
   
   if (to.matched.some(record => record.meta.requiresAuth)) {
     if (!token) {

--- a/web/src/views/Login.vue
+++ b/web/src/views/Login.vue
@@ -32,6 +32,12 @@
             Sign In
           </button>
         </div>
+        <div v-if="oidcEnabled">
+          <button type="button" @click="loginOIDC" :disabled="loading"
+                  class="relative flex justify-center w-full px-4 py-2 text-sm font-medium text-white bg-green-600 border border-transparent rounded-md group hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500 disabled:bg-green-300">
+            Use Single Sign-On
+          </button>
+        </div>
       </form>
     </div>
   </div>
@@ -39,6 +45,7 @@
 
 <script>
 import { hubApi } from '../api';
+import { getUserManager, isOidcEnabled } from '../api/oidc';
 
 export default {
   name: 'Login',
@@ -46,7 +53,8 @@ export default {
     return {
       token: '',
       loading: false,
-      error: null
+      error: null,
+      oidcEnabled: isOidcEnabled(),
     };
   },
   created() {
@@ -67,6 +75,18 @@ export default {
         hubApi.clearToken();
         this.error = 'Login failed. Please check your token.';
       } finally {
+        this.loading = false;
+      }
+    },
+    async loginOIDC() {
+      this.loading = true;
+      try {
+        await getUserManager().signinRedirect();
+      } catch (e) {
+        this.error = 'OIDC Login failed. Please check your settings.';
+        console.error(e);
+      }
+      finally {
         this.loading = false;
       }
     }

--- a/web/src/views/OidcCallback.vue
+++ b/web/src/views/OidcCallback.vue
@@ -1,0 +1,33 @@
+<template>
+  <div class="flex items-center justify-center min-h-screen">
+    <div class="text-center">
+      <p class="text-gray-600">Completing sign-in...</p>
+    </div>
+  </div>
+</template>
+
+<script>
+import { getUserManager } from '../api/oidc';
+import { hubApi } from '../api';
+export default {
+  name: 'OidcCallback',
+  async created() {    
+    console.log('OIDC callback');
+    try {
+      const user = await getUserManager().signinRedirectCallback();
+      const token = user?.id_token;
+      if (token) {
+        hubApi.setBearer(token);
+        this.$router.replace('/app');
+      } else {
+        this.$router.replace('/');
+      }
+    } catch (e) {
+      console.error('OIDC callback error', e);
+      this.$router.replace('/');
+    }
+  }
+};
+</script>
+
+


### PR DESCRIPTION
<img width="3840" height="1916" alt="image" src="https://github.com/user-attachments/assets/54e08fe6-b014-472f-9255-b41133ff1a01" />

### Overview
This PR introduces first-class OIDC SSO support alongside the existing token-based authentication, unifies auth handling across the API and follower server, and exposes a runtime `GET /auth/config` endpoint for the frontend to dynamically load OIDC settings.

### Why
- Enable enterprise SSO (Keycloak/Okta/Auth0/etc.) without hardcoding config in the frontend
- Improve security by verifying ID Tokens against the issuer and client ID
- Keep backward compatibility with existing `token` header flows for scripts/MCP
- Centralize and simplify auth logic

### What’s Changed
- **Auth core**
  - Added `src/api/auth.go`:
    - OIDC verifier initialization and ID Token verification via `go-oidc`
    - `AuthenticateRequest` supporting:
      - Legacy `token` header (unchanged behavior)
      - OIDC Bearer tokens (`Authorization: Bearer <id_token>`)
    - Allowlist enforcement via `oidc_allowed_users`
    - New `GET /auth/config` endpoint for frontend to discover OIDC settings
- **API server**
  - `src/api/server.go`:
    - CORS now explicitly allows `Authorization`
    - Public endpoints include `GET /auth/config`
    - Protected routes now use `AuthenticateRequest`
- **Follower server**
  - `src/api/follower_server.go`:
    - CORS allows `Authorization`
    - Adds `GET /auth/config`
    - Auth middleware accepts either legacy `token` or OIDC Bearer
- **Token check**
  - `src/api/cluster.go`:
    - `GET /token-check` authenticates via legacy `token` first, then OIDC if enabled
- **Config**
  - `src/common/types.go`: New OIDC fields
    - `oidc_enabled`, `oidc_issuer`, `oidc_client_id`, `oidc_username_claim`, `oidc_allowed_users`, `oidc_redirect_uri`, `oidc_scope`
- **Dependencies**
  - `src/go.mod`: Add `github.com/coreos/go-oidc/v3`, plus indirect `golang.org/x/oauth2`, `github.com/go-jose/go-jose/v4`
- **Docs**
  - `docs/agentsmith-hub-guide.md` and `docs/agentsmith-hub-guide-zh.md`: New “Authentication and Login (OIDC SSO)” section with config details and guidance
  - `web/pnpm-lock.yaml` ignored in `.gitignore`

### Configuration
- `config.yaml`:
```yaml
oidc_enabled: true
oidc_issuer: "https://your-idp/realms/your-realm"
oidc_client_id: "agentsmith-web"
oidc_redirect_uri: "https://hub.example.com/oidc/callback"
oidc_username_claim: "preferred_username"   # optional; defaults preferred_username→email
oidc_allowed_users: ["alice@example.com", "bob"]  # optional; empty means nobody allowed
oidc_scope: "openid profile email"          # optional; defaults to openid profile email
```
- Environment variable overrides (higher priority):
```bash
OIDC_ENABLED=true
OIDC_ISSUER=https://your-idp/realms/your-realm
OIDC_CLIENT_ID=agentsmith-web
OIDC_REDIRECT_URI=https://hub.example.com/oidc/callback
OIDC_USERNAME_CLAIM=preferred_username
OIDC_ALLOWED_USERS=alice@example.com,bob
OIDC_SCOPE="openid profile email"
```

Notes:
- When `oidc_enabled: true`, you must set `oidc_issuer`, `oidc_client_id`, and `oidc_redirect_uri`.
- `oidc_redirect_uri` must match the IdP client exactly (consider proxy/subpath).
- Username resolution prefers `preferred_username`, then `email`, unless overridden by `oidc_username_claim`.
- If `oidc_allowed_users` is set, access is restricted to that list; if empty, no one can log in.
- Legacy `token` header remains supported.

### New/Updated Endpoints
- Public:
  - `GET /auth/config` → returns OIDC configuration for the frontend
  - `GET /token-check` → succeeds with valid legacy token or valid OIDC ID Token (when enabled)
- Protected:
  - All authenticated routes now accept either legacy token or OIDC Bearer token

### Frontend Integration
- Frontend should call `GET /auth/config` to determine whether to show SSO button.
- Default callback route in docs: `/oidc/callback`. Ensure it’s allowed by your IdP.

### Security Considerations
- ID Tokens are verified against the configured issuer and client ID using `go-oidc`.
- Optional allowlist (`oidc_allowed_users`) restricts access by username/email claim.
- Recommend HTTPS everywhere and strict redirect URI configuration at the IdP.

### Testing
- With OIDC enabled and a valid ID Token:
```bash
curl -sS http://localhost:8080/token-check \
  -H "Authorization: Bearer <ID_TOKEN>"
```
- With legacy token:
```bash
curl -sS http://localhost:8080/token-check \
  -H "token: <your-legacy-token>"
```
- Fetch frontend config:
```bash
curl -sS http://localhost:8080/auth/config
```

### Backward Compatibility
- Legacy `token`-based auth continues to work for scripts/MCP integrations.
- No breaking API changes; `Authorization` header now permitted by CORS.