### PR TITLE
Add rules engine `<modify>`, introduce `suppress` plugin, and harden test parameter parsing

### DIFF
--- a/docs/agentsmith-hub-guide-zh.md
+++ b/docs/agentsmith-hub-guide-zh.md
@@ -1128,6 +1128,7 @@ AgentSmith-HUB 提供了丰富的内置插件，无需额外开发即可使用�
 | `cidrMatch` | 检查IP是否在CIDR范围内 | ip (string), cidr (string) | `cidrMatch(client_ip, "192.168.1.0/24")` |
 | `geoMatch` | 检查IP所属国家 | ip (string), countryISO (string) | `geoMatch(source_ip, "US")` |
 | `suppressOnce` | 告警抑制 | key (any), windowSec (int), ruleid (string, optional) | `suppressOnce(alert_key, 300, "rule_001")` |
+| `suppress` | 告警抑制(新版) | window (int or string), keyParts(...any) | `suppress(300, "rule_001", source_ip, destination_ip)`  `suppress("5m", "rule_001", source_ip, destination_ip, host_id)` |
 
 ##### 数据处理插件（返回各种类型）
 
@@ -1205,11 +1206,24 @@ AgentSmith-HUB 提供了丰富的内置插件，无需额外开发即可使用�
 ```
 
 ### 6.2 告警抑制示例
-
+旧版：
 ```xml
 <rule id="suppression_example" name="Alert Suppression">
     <check type="EQU" field="event_type">login_failed</check>
     <check type="PLUGIN">suppressOnce(source_ip, 300, "login_brute_force")</check>
+    <append field="alert_type">brute_force</append>
+</rule>
+```
+新版：
+```xml
+<rule id="suppression_example" name="Alert Suppression">
+    <check type="EQU" field="event_type">login_failed</check>
+    <check type="PLUGIN">suppress(300, "login_brute_force", source_ip)</check>
+    <append field="alert_type">brute_force</append>
+</rule>
+<rule id="suppression_example" name="Alert Suppression">
+    <check type="EQU" field="event_type">login_failed</check>
+    <check type="PLUGIN">suppress("5m", "login_brute_force", source_ip, host_id)</check>
     <append field="alert_type">brute_force</append>
 </rule>
 ```
@@ -1410,9 +1424,11 @@ AgentSmith-HUB 提供了丰富的内置插件，无需额外开发即可使用�
 </rule>
 ```
 
-#### ⚠️ 告警抑制最佳实践（suppressOnce）
+#### ⚠️ 告警抑制最佳实践
 
 告警抑制插件可以防止同一告警在短时间内重复触发。
+
+##### suppressOnce(旧版抑制插件)
 
 **为什么需要 ruleid 参数？**
 
@@ -1445,7 +1461,15 @@ AgentSmith-HUB 提供了丰富的内置插件，无需额外开发即可使用�
     <check type="PLUGIN">suppressOnce(source_ip, 300, "login_anomaly")</check>
 </rule>
 ```
+##### suppress(新版抑制插件)
 
+在新版本抑制插件中，时间窗口被放在了第一个参数，并同时支持通过传入字符串或整数的形式进行设置，例如：
+- 字符串：5m, 1h, 24h
+- 整数：300, 3600, 86400
+
+同时，考虑到众多场景下会使用不只一个数据字段作为抑制的Key，插件在第二个参数及之后支持传入任意多个字段，这些字段在抑制时会被拼接成一个Key，从而满足上述使用需求。
+
+值得注意的是，与旧版本插件相同，如果不希望不同规则对同一Key的抑制相互影响，需要在第二个参数及之后传入告警的唯一标识作为Key的一部分。
 ### 6.4 排除规则集
 
 排除用于过滤掉不需要处理的数据（ruleset type 为 EXCLUDE）。排除的特殊行为：

--- a/docs/agentsmith-hub-guide-zh.md
+++ b/docs/agentsmith-hub-guide-zh.md
@@ -695,7 +695,7 @@ OIDC_SCOPE="openid profile email"
 **执行流程：**
 - 规则引擎按照 XML 中标签的出现顺序执行操作
 - 检查类操作（check、threshold）如果失败，规则立即结束
-- 处理类操作（append、del、plugin）只在所有检查通过后执行
+- 处理类操作（append、modify、del、plugin）只在所有检查通过后执行
 
 #### 🔍 语法详解：`<threshold>` 标签
 
@@ -1934,6 +1934,25 @@ AgentSmith-HUB 提供了丰富的内置插件，无需额外开发即可使用�
 #### 插件执行 `<plugin>`
 ```xml
 <plugin>插件函数(参数1, 参数2)</plugin>
+```
+
+#### 字段修改 `<modify>`
+```xml
+<modify field="字段名">值</modify>
+```
+
+- 用于更新已有字段，或替换整条记录。
+- 通过可选的 `type` 属性支持两种模式：
+  - 空（字面量赋值，默认）：将标签体文本赋值给 `field`
+  - `PLUGIN`：执行插件并使用其返回值设置`field`或者替换整条记录(当field未指定时)。
+
+语法（PLUGIN 模式）：
+```xml
+<!-- 将插件返回值赋给某个字段 -->
+<modify type="PLUGIN" field="risk_score">calculateRisk(amount, user.daily_limit)</modify>
+
+<!-- 用插件返回的整对象替换当前记录 -->
+<modify type="PLUGIN">transformRecord(_$ORIDATA)</modify>
 ```
 
 ### 8.6 字段访问语法

--- a/docs/agentsmith-hub-guide.md
+++ b/docs/agentsmith-hub-guide.md
@@ -1133,6 +1133,7 @@ AgentSmith-HUB provides rich built-in plugins that can be used without additiona
 | `cidrMatch` | Check if IP is in CIDR range | ip (string), cidr (string) | `cidrMatch(client_ip, "192.168.1.0/24")` |
 | `geoMatch` | Check IP's country | ip (string), countryISO (string) | `geoMatch(source_ip, "US")` |
 | `suppressOnce` | Alert suppression | key (any), windowSec (int), ruleid (string, optional) | `suppressOnce(alert_key, 300, "rule_001")` |
+| `suppress` | Alert suppression (new) | window (int or string), keyParts(...any) | `suppress(300, "rule_001", source_ip, destination_ip)`  `suppress("5m", "rule_001", source_ip, destination_ip, host_id)` |
 
 ##### Data Processing Plugins (Return various types)
 
@@ -1211,10 +1212,24 @@ AgentSmith-HUB provides rich built-in plugins that can be used without additiona
 
 ### 6.2 Alert Suppression Example
 
+Old version:
 ```xml
 <rule id="suppression_example" name="Alert Suppression">
     <check type="EQU" field="event_type">login_failed</check>
     <check type="PLUGIN">suppressOnce(source_ip, 300, "login_brute_force")</check>
+    <append field="alert_type">brute_force</append>
+</rule>
+```
+New version:
+```xml
+<rule id="suppression_example" name="Alert Suppression">
+    <check type="EQU" field="event_type">login_failed</check>
+    <check type="PLUGIN">suppress(300, "login_brute_force", source_ip)</check>
+    <append field="alert_type">brute_force</append>
+</rule>
+<rule id="suppression_example" name="Alert Suppression">
+    <check type="EQU" field="event_type">login_failed</check>
+    <check type="PLUGIN">suppress("5m", "login_brute_force", source_ip, host_id)</check>
     <append field="alert_type">brute_force</append>
 </rule>
 ```
@@ -1415,9 +1430,11 @@ Log processing rule:
 </rule>
 ```
 
-#### ⚠️ Alert Suppression Best Practices (suppressOnce)
+#### ⚠️ Alert Suppression Best Practices
 
 The alert suppression plugin can prevent the same alert from triggering repeatedly in a short time.
+
+##### suppressOnce (Old suppression plugin)
 
 **Why do we need the ruleid parameter?**
 
@@ -1450,6 +1467,15 @@ If you don't use the `ruleid` parameter, suppression of the same key by differen
     <check type="PLUGIN">suppressOnce(source_ip, 300, "login_anomaly")</check>
 </rule>
 ```
+##### suppress (New suppression plugin)
+
+In the new suppression plugin, the time window is the first parameter, and both string and integer forms are supported, for example:
+- Strings: 5m, 1h, 24h
+- Integers: 300, 3600, 86400
+
+Also, as many scenarios require using more than one data field as the suppression key, the plugin supports passing any number of fields from the second parameter onward. These fields are concatenated to form a single key, meeting the above requirement.
+
+Note: same as the old plugin, if you do not want suppressions for the same key to interfere across different rules, include a unique alert identifier (e.g., the rule id) as part of the key from the second parameter onward.
 
 ### 6.4 Exclude Ruleset
 

--- a/docs/agentsmith-hub-guide.md
+++ b/docs/agentsmith-hub-guide.md
@@ -699,7 +699,7 @@ One of the major features of the rules engine is flexible execution order:
 **Execution Flow:**
 - The rules engine executes operations according to the appearance order of tags in XML
 - If check operations (check, threshold) fail, the rule ends immediately
-- Processing operations (append, del, plugin) only execute after all checks pass
+- Processing operations (append, modify, del, plugin) only execute after all checks pass
 
 #### 🔍 Syntax Details: `<threshold>` Tag
 
@@ -1939,6 +1939,25 @@ When a ruleset contains multiple `<rule>` elements, they have an **OR relationsh
 #### Plugin Execution `<plugin>`
 ```xml
 <plugin>plugin_function(parameter1, parameter2)</plugin>
+```
+
+#### Field Modify `<modify>`
+```xml
+<modify field="field_name">value</modify>
+```
+
+- Use to update an existing field or replace the entire record.
+- Two modes are supported via the optional `type` attribute:
+  - Empty (literal assignment, default): assign the literal body text to `field`.
+  - `PLUGIN`: execute a plugin and use its return value to set specified `field` or replace the entire record(only when `field` is undefined).
+
+Syntax (PLUGIN mode):
+```xml
+<!-- Assign plugin result to a field -->
+<modify type="PLUGIN" field="risk_score">calculateRisk(amount, user.daily_limit)</modify>
+
+<!-- Replace entire data with plugin result (must return a map) -->
+<modify type="PLUGIN">transformRecord(_$ORIDATA)</modify>
 ```
 
 ### 8.6 Field Access Syntax

--- a/src/api/testing.go
+++ b/src/api/testing.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"net/http"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -309,15 +310,17 @@ func testPlugin(c echo.Context) error {
 	}
 
 	// Process parameter values, try to convert to appropriate types
-	args := make([]interface{}, 0)
-	for _, value := range req.Data {
-		// Convert to appropriate types
-		if str, ok := value.(string); ok {
-			args = append(args, str)
-		} else {
-			// Convert other types to string
-			args = append(args, fmt.Sprintf("%v", value))
+	args := make([]interface{}, len(req.Data))
+	for key, value := range req.Data {
+		intKey, err := strconv.Atoi(key)
+		if err != nil {
+			return c.JSON(http.StatusOK, map[string]interface{}{
+				"success": false,
+				"error":   "Invalid key: " + key,
+				"result":  nil,
+			})
 		}
+		args[intKey] = value
 	}
 
 	// Determine plugin type and execute

--- a/src/local_plugin/local_plugin.go
+++ b/src/local_plugin/local_plugin.go
@@ -41,6 +41,7 @@ import (
 
 	// threat intelligence
 	shodan "AgentSmith-HUB/local_plugin/shodan"
+	suppress "AgentSmith-HUB/local_plugin/suppress"
 	threatbook "AgentSmith-HUB/local_plugin/threatbook"
 	virustotal "AgentSmith-HUB/local_plugin/virustotal"
 )
@@ -51,6 +52,7 @@ var LocalPluginBoolRes = map[string]func(...interface{}) (bool, error){
 	"cidrMatch":    cidr_match.Eval,
 	"geoMatch":     geo_match.Eval,
 	"suppressOnce": suppressonce.Eval,
+	"suppress":     suppress.Eval,
 }
 
 // for append or other usage

--- a/src/local_plugin/suppress/suppress.go
+++ b/src/local_plugin/suppress/suppress.go
@@ -1,0 +1,58 @@
+package suppress
+
+import (
+	"AgentSmith-HUB/common"
+	"fmt"
+	"strconv"
+)
+
+// Eval implements a suppression plugin: for the same key, return true only once
+// within the provided time window (seconds). Args:
+//
+//	0: window — suppression window (int seconds or duration string like "30s", "2m")
+//	1..n: key parts — remaining args are concatenated (stringified) to form the key
+//
+// Behavior: returns true at most once per key within the window; subsequent calls
+// until expiry return false. Implemented via Redis SETNX with TTL.
+func Eval(args ...interface{}) (bool, error) {
+	if len(args) < 2 {
+		return false, fmt.Errorf("suppress requires at least 2 arguments: windows and the suppress key")
+	}
+
+	// parse window seconds
+	var winSec int
+	switch v := args[0].(type) {
+	case int:
+		winSec = v
+	case int64:
+		winSec = int(v)
+	case float64:
+		winSec = int(v)
+	case string:
+		i, err := strconv.Atoi(v)
+		if err != nil {
+			winSec, err = common.ParseDurationToSecondsInt(v)
+			if err != nil {
+				return false, fmt.Errorf("invalid window seconds: %v", v)
+			}
+		}
+		winSec = i
+	default:
+		return false, fmt.Errorf("unsupported window type %T", v)
+	}
+	if winSec <= 0 {
+		return false, fmt.Errorf("window must be positive seconds")
+	}
+
+	redisKey := "suppress"
+	for _, arg := range args[1:] {
+		redisKey += fmt.Sprintf(":%v", arg)
+	}
+
+	ok, err := common.RedisSetNX(redisKey, 1, winSec)
+	if err != nil {
+		return false, err
+	}
+	// ok==true means first time within window → return true; else false
+	return ok, nil
+}

--- a/src/local_plugin/suppress/suppress.go
+++ b/src/local_plugin/suppress/suppress.go
@@ -31,7 +31,7 @@ func Eval(args ...interface{}) (bool, error) {
 	case string:
 		i, err := strconv.Atoi(v)
 		if err != nil {
-			winSec, err = common.ParseDurationToSecondsInt(v)
+			i, err = common.ParseDurationToSecondsInt(v)
 			if err != nil {
 				return false, fmt.Errorf("invalid window seconds: %v", v)
 			}

--- a/src/rules_engine/engine_core.go
+++ b/src/rules_engine/engine_core.go
@@ -4,6 +4,7 @@ import (
 	"AgentSmith-HUB/common"
 	"AgentSmith-HUB/logger"
 	"fmt"
+	"maps"
 	"strconv"
 	"strings"
 	"sync"
@@ -535,6 +536,9 @@ func (r *Ruleset) executeRuleOperations(rule *Rule, data map[string]interface{},
 		case T_Append:
 			// Execute append operation according to user-defined order
 			r.executeAppend(rule, op.ID, data, ruleCache)
+		case T_Modify:
+			// Execute modify operation according to user-defined order
+			r.executeModify(rule, op.ID, data, ruleCache)
 		case T_Del:
 			// Execute del operation according to user-defined order
 			r.executeDel(rule, op.ID, data)
@@ -811,6 +815,68 @@ func (r *Ruleset) executeAppend(rule *Rule, operationID int, dataCopy map[string
 				logger.PluginError("Interface-type plugin evaluation error in append", "plugin", appendOp.Plugin.Name, "error", err)
 			}
 		}
+	}
+}
+
+// executeModify executes a modify operation
+func (r *Ruleset) executeModify(rule *Rule, operationID int, dataCopy map[string]interface{}, ruleCache map[string]common.CheckCoreCache) {
+	modifyOp, exists := rule.ModifyMap[operationID]
+	if !exists {
+		return
+	}
+
+	// Handle by type
+	if strings.TrimSpace(modifyOp.Type) == "" {
+		// Literal assignment mode; field must be present (enforced in build/validation)
+		dataCopy[modifyOp.FieldName] = modifyOp.Value
+		return
+	}
+
+	// Plugin mode
+	args := GetPluginRealArgs(modifyOp.PluginArgs, dataCopy, ruleCache)
+
+	// Check plugin return type to determine which evaluation method to use
+	if modifyOp.Plugin.ReturnType == "bool" {
+		boolResult, err := modifyOp.Plugin.FuncEvalCheckNode(args...)
+		if err != nil {
+			logger.PluginError("Check-type plugin evaluation error in modify", "plugin", modifyOp.Plugin.Name, "error", err)
+			return
+		}
+		if modifyOp.FieldName != "" {
+			dataCopy[modifyOp.FieldName] = boolResult
+		} else {
+			logger.PluginError("Modify without field requires map result; got bool", "plugin", modifyOp.Plugin.Name, "ruleID", rule.ID)
+		}
+		return
+	}
+
+	// For interface{} type plugins, use FuncEvalOther
+	res, ok, err := modifyOp.Plugin.FuncEvalOther(args...)
+	if err != nil || !ok {
+		if err != nil {
+			logger.PluginError("Interface-type plugin evaluation error in modify", "plugin", modifyOp.Plugin.Name, "error", err)
+		}
+		return
+	}
+
+	if modifyOp.FieldName != "" {
+		if modifyOp.FieldName == PluginArgFromRawSymbol {
+			if rmap, ok := res.(map[string]interface{}); ok {
+				res = common.MapDeepCopy(rmap)
+			} else {
+				logger.PluginError("Plugin result is not a map", "plugin", modifyOp.Plugin.Name, "result", res)
+				res = nil
+			}
+		}
+		dataCopy[modifyOp.FieldName] = res
+		return
+	}
+
+	if rmap, ok := res.(map[string]interface{}); ok {
+		clear(dataCopy)
+		maps.Copy(dataCopy, rmap)
+	} else {
+		logger.PluginError("Modify without field expects map result to replace data", "plugin", modifyOp.Plugin.Name, "result", res)
 	}
 }
 
@@ -1169,7 +1235,7 @@ func (r *Ruleset) ruleModifiesData(rule *Rule) bool {
 
 	for _, op := range *rule.Queue {
 		switch op.Type {
-		case T_Append, T_Del, T_Plugin:
+		case T_Append, T_Del, T_Plugin, T_Modify:
 			return true // These operations modify data
 		}
 	}

--- a/web/src/components/MonacoEditor.vue
+++ b/web/src/components/MonacoEditor.vue
@@ -3179,6 +3179,12 @@ function getXmlAttributeValueCompletions(context, range) {
     );
   }
 
+  else if (context.currentTag === 'modify' && context.currentAttribute === 'type') {
+    suggestions.push(
+      { label: 'PLUGIN', kind: monaco.languages.CompletionItemKind.EnumMember, documentation: 'Plugin-based modify', insertText: 'PLUGIN', range: range }
+    );
+  }
+
   else if (context.currentTag === 'iterator' && context.currentAttribute === 'type') {
     suggestions.push(
       { label: 'ALL', kind: monaco.languages.CompletionItemKind.EnumMember, documentation: 'Return true if all elements are true', insertText: 'ALL', range: range },
@@ -3390,6 +3396,14 @@ function getXmlAttributeNameCompletions(context, range) {
         { label: 'type', kind: monaco.languages.CompletionItemKind.Property, documentation: 'Append type (PLUGIN for dynamic values)', insertText: 'type="PLUGIN"', range: range }
       );
       break;
+    
+    case 'modify':
+      suggestions.push(
+        { label: 'field', kind: monaco.languages.CompletionItemKind.Property, documentation: 'Name of field to modify', insertText: 'field="field-name"', insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet, range: range },
+        { label: 'type', kind: monaco.languages.CompletionItemKind.Property, documentation: 'Modify type (PLUGIN for dynamic values)', insertText: 'type="PLUGIN"', range: range }
+      );
+      break;
+
     case 'iterator':
       suggestions.push(
         { label: 'type', kind: monaco.languages.CompletionItemKind.Property, documentation: 'Iterator type', insertText: 'type="ALL"', range: range },
@@ -3484,6 +3498,14 @@ function getXmlTagNameCompletions(context, range, fullText) {
         insertText: 'append field="field_name">value</append',
         range: range,
         sortText: '4_append'
+      },
+      {
+        label: 'modify',
+        kind: monaco.languages.CompletionItemKind.Property,
+        documentation: 'Modify field to result (can be placed anywhere in rule)',
+        insertText: 'modify field="field_name">value</modify',
+        range: range,
+        sortText: '4_modify'
       },
       {
         label: 'plugin',
@@ -3597,6 +3619,14 @@ function getXmlTagNameCompletions(context, range, fullText) {
         sortText: '4_append'
       },
       {
+        label: 'modify',
+        kind: monaco.languages.CompletionItemKind.Property,
+        documentation: 'Modify field to result',
+        insertText: 'modify field="field_name">value</modify',
+        range: range,
+        sortText: '4_modify'
+      },
+      {
         label: 'plugin',
         kind: monaco.languages.CompletionItemKind.Function,
         documentation: 'Plugin execution',
@@ -3645,7 +3675,8 @@ function getXmlTagContentCompletions(context, range, fullText) {
   if (context.currentTag === 'plugin' || 
       (context.currentTag === 'check' && fullText.includes('type="PLUGIN"')) || 
       (context.currentTag === 'node' && fullText.includes('type="PLUGIN"')) || 
-      (context.currentTag === 'append' && fullText.includes('type="PLUGIN"'))) {
+      (context.currentTag === 'append' && fullText.includes('type="PLUGIN"'))||
+      (context.currentTag === 'modify' && fullText.includes('type="PLUGIN"'))) {
     
     // Determine if we're in a check context (which requires bool return type)
     const isInCheckNode = (context.currentTag === 'check' || context.currentTag === 'node') && fullText.includes('type="PLUGIN"');


### PR DESCRIPTION
### Overview
This PR adds in-place record update capability to the rules engine via a new `<modify>` operation, introduces a flexible `suppress` local plugin for alert suppression, and hardens the plugin testing flow by validating parameter keys.

### Why
- Enable precise, in-place updates to records without requiring delete+append flows.
- Reduce alert noise with configurable suppression windows and composite keys.
- Improve robustness of the plugin testing API by validating parameter shapes and returning structured errors.

### What’s Changed
- Rules engine
  - Add `<modify>` operation: parsing, validation, and execution support.
  - Update `engine_core.go`, `engine_parser.go`, `engine_struct.go` to handle modify alongside append/delete/plugin.
  - Enhance `MonacoEditor.vue` to surface the new operation in syntax support/snippets.
- Local plugins
  - Introduce `suppress` plugin with configurable time windows and multiple key parts.
  - Register the plugin in `local_plugin.go`.
  - Keep `suppressOnce` available; docs updated to show both and best practices.
- API
  - Harden test plugin parameter handling in `testing.go`: convert parameter keys to integers; return JSON error on invalid keys.
  - Minor update to `suppress.go` related to parameter handling.
- Docs
  - Update `agentsmith-hub-guide.md` and `agentsmith-hub-guide-zh.md` with:
    - `<modify>` usage, execution flow, and syntax examples.
    - `suppress` plugin examples and guidance.
    - Comparison and migration notes for `suppressOnce` vs `suppress`.

### Frontend Integration
- `MonacoEditor.vue` updated to support `<modify>` syntax, hints, and examples.

### Backward Compatibility
- Existing append/delete/plugin operations remain unchanged.
- `suppressOnce` remains supported; docs add guidance on when to prefer `suppress`.

### Commits Included
- d9ccc23: fix: handle invalid keys in testPlugin parameter processing
- 8bfb1d2: feat: add new alert suppression plugin and update documentation
- 03f716a: feat: add support for `<modify>` operation in rules engine

### Files Changed (high level)
- Rules engine: `src/rules_engine/engine_core.go`, `engine_parser.go`, `engine_struct.go`
- Local plugins: `src/local_plugin/suppress/suppress.go`, `src/local_plugin/local_plugin.go`
- API/testing: `src/api/testing.go`
- Frontend: `web/src/components/MonacoEditor.vue`
- Docs: `docs/agentsmith-hub-guide.md`, `docs/agentsmith-hub-guide-zh.md`
