### PR TITLE
fix(rules_engine): clean up expired local cache state

### DIFF
--- a/src/rules_engine/cep_state.go
+++ b/src/rules_engine/cep_state.go
@@ -137,7 +137,8 @@ type CEPStateManager struct {
 	// Multiple goroutines (from different upstreams) may process events for the
 	// same correlation key simultaneously. Without per-key locking, concurrent
 	// AddMatch calls would cause map data races.
-	keyLocks sync.Map // map[string]*sync.Mutex
+	keyLocks   sync.Map // map[string]*refCountedKeyLock
+	keyLocksMu sync.Mutex
 
 	// For absence scanning: track keys that have absence stages (local cache mode)
 	absenceKeys   map[string]absenceKeyInfo
@@ -166,6 +167,11 @@ type absenceSlotItem struct {
 	Info absenceKeyInfo
 }
 
+type refCountedKeyLock struct {
+	mu   sync.Mutex
+	refs int
+}
+
 // NewCEPStateManager creates a new state manager.
 func NewCEPStateManager(useLocalCache bool, cache *ristretto.Cache[string, *SequenceState]) *CEPStateManager {
 	m := &CEPStateManager{
@@ -189,22 +195,44 @@ func BuildStateKey(groupByID string, correlateValues string) string {
 // LockKey acquires a per-key mutex, ensuring exclusive access to a SequenceState.
 // Must be paired with UnlockKey. Used to protect the entire read-modify-write cycle.
 func (m *CEPStateManager) LockKey(key string) {
-	actual, _ := m.keyLocks.LoadOrStore(key, &sync.Mutex{})
-	actual.(*sync.Mutex).Lock()
+	m.keyLocksMu.Lock()
+	actual, ok := m.keyLocks.Load(key)
+	var keyLock *refCountedKeyLock
+	if ok {
+		keyLock = actual.(*refCountedKeyLock)
+	} else {
+		keyLock = &refCountedKeyLock{}
+		m.keyLocks.Store(key, keyLock)
+	}
+	keyLock.refs++
+	m.keyLocksMu.Unlock()
+
+	keyLock.mu.Lock()
 }
 
 // UnlockKey releases the per-key mutex.
 func (m *CEPStateManager) UnlockKey(key string) {
-	if actual, ok := m.keyLocks.Load(key); ok {
-		actual.(*sync.Mutex).Unlock()
+	m.keyLocksMu.Lock()
+	actual, ok := m.keyLocks.Load(key)
+	if !ok {
+		m.keyLocksMu.Unlock()
+		return
 	}
+
+	keyLock := actual.(*refCountedKeyLock)
+	if keyLock.refs > 0 {
+		keyLock.refs--
+	}
+	keyLock.mu.Unlock()
+	if keyLock.refs == 0 {
+		m.keyLocks.Delete(key)
+	}
+	m.keyLocksMu.Unlock()
 }
 
-// CleanupKeyLock removes a key lock entry after the state is deleted.
-// NOTE: intentionally kept as no-op to avoid lock replacement races:
-// deleting a lock while another goroutine still holds it can cause a later
-// goroutine to recreate a new mutex for the same key, breaking exclusion and
-// leading to unlock panics. We prefer correctness/stability here.
+// CleanupKeyLock is kept for callers that explicitly clean up after deleting a
+// state. Lock entries are now released automatically by UnlockKey once the last
+// holder or waiter leaves, avoiding lock replacement races.
 func (m *CEPStateManager) CleanupKeyLock(key string) {
 	_ = key
 }

--- a/src/rules_engine/cep_test.go
+++ b/src/rules_engine/cep_test.go
@@ -863,6 +863,25 @@ func TestCEPStateManager_LocalCache_Delete(t *testing.T) {
 	}
 }
 
+func TestCEPStateManager_KeyLocksReleasedAfterUnlock(t *testing.T) {
+	cache := newTestLocalCache()
+	defer cache.Close()
+	mgr := NewCEPStateManager(true, cache)
+
+	mgr.LockKey("transient_key")
+	mgr.UnlockKey("transient_key")
+	mgr.CleanupKeyLock("transient_key")
+
+	count := 0
+	mgr.keyLocks.Range(func(_, _ interface{}) bool {
+		count++
+		return true
+	})
+	if count != 0 {
+		t.Fatalf("expected key lock entry to be released, got %d", count)
+	}
+}
+
 func TestCEPStateManager_LocalCache_GetOrCreate(t *testing.T) {
 	cache := newTestLocalCache()
 	defer cache.Close()

--- a/src/rules_engine/engine_threshold_cache.go
+++ b/src/rules_engine/engine_threshold_cache.go
@@ -13,8 +13,9 @@ import (
 // Each method is protected by its own fine-grained mutex, so different keys can
 // be operated on concurrently without contention on the ruleset-level r.mu lock.
 type localThresholdCounter struct {
-	mu      sync.RWMutex
-	entries map[string]counterEntry
+	mu         sync.RWMutex
+	entries    map[string]counterEntry
+	nextExpiry time.Time
 }
 
 type counterEntry struct {
@@ -28,20 +29,43 @@ func newLocalThresholdCounter() *localThresholdCounter {
 	}
 }
 
+func (c *localThresholdCounter) rememberNextExpiryLocked(expiresAt time.Time) {
+	if c.nextExpiry.IsZero() || expiresAt.Before(c.nextExpiry) {
+		c.nextExpiry = expiresAt
+	}
+}
+
+func (c *localThresholdCounter) sweepExpiredLocked(now time.Time) {
+	if c.nextExpiry.IsZero() || now.Before(c.nextExpiry) {
+		return
+	}
+
+	c.nextExpiry = time.Time{}
+	for key, entry := range c.entries {
+		if !now.Before(entry.expiresAt) {
+			delete(c.entries, key)
+			continue
+		}
+		c.rememberNextExpiryLocked(entry.expiresAt)
+	}
+}
+
 // Get returns the current value and whether the key exists and has not expired.
 func (c *localThresholdCounter) Get(key string) (int, bool) {
+	now := time.Now()
 	c.mu.RLock()
 	entry, ok := c.entries[key]
 	if !ok {
 		c.mu.RUnlock()
 		return 0, false
 	}
-	if time.Now().After(entry.expiresAt) {
+	if !now.Before(entry.expiresAt) {
 		c.mu.RUnlock()
 		c.mu.Lock()
 		defer c.mu.Unlock()
+		c.sweepExpiredLocked(now)
 		entry, ok = c.entries[key]
-		if !ok || time.Now().After(entry.expiresAt) {
+		if !ok || !now.Before(entry.expiresAt) {
 			delete(c.entries, key)
 			return 0, false
 		}
@@ -53,22 +77,24 @@ func (c *localThresholdCounter) Get(key string) (int, bool) {
 
 // GetTTL returns the remaining TTL for an existing non-expired key.
 func (c *localThresholdCounter) GetTTL(key string) (time.Duration, bool) {
+	now := time.Now()
 	c.mu.RLock()
 	entry, ok := c.entries[key]
 	if !ok {
 		c.mu.RUnlock()
 		return 0, false
 	}
-	remaining := time.Until(entry.expiresAt)
+	remaining := entry.expiresAt.Sub(now)
 	if remaining <= 0 {
 		c.mu.RUnlock()
 		c.mu.Lock()
 		defer c.mu.Unlock()
+		c.sweepExpiredLocked(now)
 		entry, ok = c.entries[key]
 		if !ok {
 			return 0, false
 		}
-		remaining = time.Until(entry.expiresAt)
+		remaining = entry.expiresAt.Sub(now)
 		if remaining <= 0 {
 			delete(c.entries, key)
 			return 0, false
@@ -81,9 +107,13 @@ func (c *localThresholdCounter) GetTTL(key string) (time.Duration, bool) {
 
 // SetWithTTL stores value with the given TTL, overwriting any existing entry.
 func (c *localThresholdCounter) SetWithTTL(key string, value int, ttl time.Duration) {
+	now := time.Now()
+	expiresAt := now.Add(ttl)
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.entries[key] = counterEntry{value: value, expiresAt: time.Now().Add(ttl)}
+	c.sweepExpiredLocked(now)
+	c.entries[key] = counterEntry{value: value, expiresAt: expiresAt}
+	c.rememberNextExpiryLocked(expiresAt)
 }
 
 // Del removes a key from the counter map.
@@ -98,6 +128,7 @@ func (c *localThresholdCounter) Close() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.entries = make(map[string]counterEntry)
+	c.nextExpiry = time.Time{}
 }
 
 // ---
@@ -106,8 +137,9 @@ func (c *localThresholdCounter) Close() {
 // It replaces ristretto.Cache[string, map[string]bool] for CLASSIFY threshold
 // operations, with the same guarantees as localThresholdCounter.
 type localClassifyCounter struct {
-	mu      sync.RWMutex
-	entries map[string]classifyEntry
+	mu         sync.RWMutex
+	entries    map[string]classifyEntry
+	nextExpiry time.Time
 }
 
 type classifyEntry struct {
@@ -121,21 +153,44 @@ func newLocalClassifyCounter() *localClassifyCounter {
 	}
 }
 
+func (c *localClassifyCounter) rememberNextExpiryLocked(expiresAt time.Time) {
+	if c.nextExpiry.IsZero() || expiresAt.Before(c.nextExpiry) {
+		c.nextExpiry = expiresAt
+	}
+}
+
+func (c *localClassifyCounter) sweepExpiredLocked(now time.Time) {
+	if c.nextExpiry.IsZero() || now.Before(c.nextExpiry) {
+		return
+	}
+
+	c.nextExpiry = time.Time{}
+	for key, entry := range c.entries {
+		if !now.Before(entry.expiresAt) {
+			delete(c.entries, key)
+			continue
+		}
+		c.rememberNextExpiryLocked(entry.expiresAt)
+	}
+}
+
 // Get returns a copy of the key set and whether the entry exists and has not expired.
 // A copy is returned to allow the caller to mutate it safely.
 func (c *localClassifyCounter) Get(key string) (map[string]bool, bool) {
+	now := time.Now()
 	c.mu.RLock()
 	entry, ok := c.entries[key]
 	if !ok {
 		c.mu.RUnlock()
 		return nil, false
 	}
-	if time.Now().After(entry.expiresAt) {
+	if !now.Before(entry.expiresAt) {
 		c.mu.RUnlock()
 		c.mu.Lock()
 		defer c.mu.Unlock()
+		c.sweepExpiredLocked(now)
 		entry, ok = c.entries[key]
-		if !ok || time.Now().After(entry.expiresAt) {
+		if !ok || !now.Before(entry.expiresAt) {
 			delete(c.entries, key)
 			return nil, false
 		}
@@ -155,9 +210,13 @@ func (c *localClassifyCounter) Get(key string) (map[string]bool, bool) {
 
 // SetWithTTL stores a key set with the given TTL, overwriting any existing entry.
 func (c *localClassifyCounter) SetWithTTL(key string, keys map[string]bool, ttl time.Duration) {
+	now := time.Now()
+	expiresAt := now.Add(ttl)
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.entries[key] = classifyEntry{keys: keys, expiresAt: time.Now().Add(ttl)}
+	c.sweepExpiredLocked(now)
+	c.entries[key] = classifyEntry{keys: keys, expiresAt: expiresAt}
+	c.rememberNextExpiryLocked(expiresAt)
 }
 
 // Del removes a key from the classify map.
@@ -172,4 +231,5 @@ func (c *localClassifyCounter) Close() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.entries = make(map[string]classifyEntry)
+	c.nextExpiry = time.Time{}
 }

--- a/src/rules_engine/engine_threshold_cache_test.go
+++ b/src/rules_engine/engine_threshold_cache_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 )
 
 // buildThresholdRuleset wraps buildRulesetFromXML and registers cache cleanup.
@@ -27,6 +28,44 @@ func buildThresholdRuleset(tb testing.TB, xml string) *Ruleset {
 	rs := buildRulesetFromXML(tb, xml)
 	tb.Cleanup(func() { rs.cleanup() })
 	return rs
+}
+
+func TestLocalThresholdCounter_SweepsExpiredEntriesOnWrite(t *testing.T) {
+	counter := newLocalThresholdCounter()
+	defer counter.Close()
+
+	counter.SetWithTTL("expired-1", 1, 10*time.Millisecond)
+	counter.SetWithTTL("expired-2", 2, 10*time.Millisecond)
+	time.Sleep(30 * time.Millisecond)
+	counter.SetWithTTL("active", 3, time.Minute)
+
+	counter.mu.RLock()
+	defer counter.mu.RUnlock()
+	if len(counter.entries) != 1 {
+		t.Fatalf("expected only active entry after write-time sweep, got %d entries", len(counter.entries))
+	}
+	if _, ok := counter.entries["active"]; !ok {
+		t.Fatal("expected active entry to remain after write-time sweep")
+	}
+}
+
+func TestLocalClassifyCounter_SweepsExpiredEntriesOnWrite(t *testing.T) {
+	counter := newLocalClassifyCounter()
+	defer counter.Close()
+
+	counter.SetWithTTL("expired-1", map[string]bool{"a": true}, 10*time.Millisecond)
+	counter.SetWithTTL("expired-2", map[string]bool{"b": true}, 10*time.Millisecond)
+	time.Sleep(30 * time.Millisecond)
+	counter.SetWithTTL("active", map[string]bool{"c": true}, time.Minute)
+
+	counter.mu.RLock()
+	defer counter.mu.RUnlock()
+	if len(counter.entries) != 1 {
+		t.Fatalf("expected only active entry after write-time sweep, got %d entries", len(counter.entries))
+	}
+	if _, ok := counter.entries["active"]; !ok {
+		t.Fatal("expected active entry to remain after write-time sweep")
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -199,7 +238,7 @@ func TestThreshold_SUM_AccumulatesAcrossEvents(t *testing.T) {
 		return map[string]interface{}{"uid": "u1", "bytes": fmt.Sprintf("%d", b)}
 	}
 
-	rs.EngineCheck(mk(40)) // seeds 40
+	rs.EngineCheck(mk(40))                            // seeds 40
 	if out := rs.EngineCheck(mk(40)); len(out) != 0 { // 40+40=80 ≤ 100
 		t.Fatalf("2nd event (sum=80): should not fire, got %d", len(out))
 	}


### PR DESCRIPTION
## Summary
- Fix threshold local-cache entries that expired but stayed in the in-memory maps until ruleset cleanup.
- Release CEP sequence per-key lock entries after the last holder/waiter leaves, avoiding high-cardinality lock accumulation.
- Add regression tests for threshold/classify expiry cleanup and CEP key-lock cleanup.

Fixes #48

## Tests
- `CGO_ENABLED=1 CGO_LDFLAGS="-L../lib/darwin -lrure" go test ./rules_engine -run "TestLocalThresholdCounter_SweepsExpiredEntriesOnWrite|TestLocalClassifyCounter_SweepsExpiredEntriesOnWrite|TestCEPStateManager_KeyLocksReleasedAfterUnlock"`
- `CGO_ENABLED=1 CGO_LDFLAGS="-L../lib/darwin -lrure" go test ./rules_engine -skip TestCEP_Stress_10Minutes`
- `CGO_ENABLED=1 CGO_LDFLAGS="-L../lib/darwin -lrure" go test ./... -skip TestCEP_Stress_10Minutes`
- `CGO_ENABLED=1 CGO_LDFLAGS="-L../lib/darwin -lrure" go test -race ./rules_engine -run "TestThreshold_Count_Concurrent|TestThreshold_SUM_Concurrent|TestCEPStateManager_KeyLocksReleasedAfterUnlock"`

Note: plain `go test ./rules_engine` hit Go's default 10m timeout in the existing `TestCEP_Stress_10Minutes` long-running stress test, so the normal package/all-package verification excludes that long test explicitly.