### PR TITLE
feat(config): support LLM_API_KEY/BASE_URL/MODEL env overrides

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -747,7 +747,18 @@ func loadHubConfig(root string) error {
 		}
 	}
 
-	// Set config root
+	// Set LLM environment override
+	if v := os.Getenv("LLM_API_KEY"); v != "" {
+		common.Config.LLMApiKey = v
+	}
+	if v := os.Getenv("LLM_BASE_URL"); v != "" {
+		common.Config.LLMBaseURL = v
+	}
+	if v := os.Getenv("LLM_MODEL"); v != "" {
+		common.Config.LLMModel = v
+	}
+
+	//Set config root
 	common.Config.ConfigRoot = root
 
 	// Validate Redis configuration


### PR DESCRIPTION
adds the missing LLM env overrides in `loadHubConfig`, bringing the code in line with the documented behavior.

https://github.com/EBWi11/AgentSmith-HUB/blob/49b2713ab105f16f22dcc81f41608fa22caeef57/docs/agentsmith-hub-guide-zh.md?plain=1#L735-L742
